### PR TITLE
Added code to check if symlink already exists

### DIFF
--- a/nodejs/server.js
+++ b/nodejs/server.js
@@ -83,8 +83,10 @@ function specialize(req, res) {
     // function deps in the right place in argv.codepath; b ut for now we
     // just symlink the function's node_modules to the server's
     // node_modules.
-    fs.symlinkSync('/usr/src/app/node_modules', `${path.dirname(modulepath)}/node_modules`);
-
+    // Check for symlink, because the link exists if the container restarts
+    if (!fs.existsSync(`${path.dirname(modulepath)}/node_modules`)) {
+        fs.symlinkSync('/usr/src/app/node_modules', `${path.dirname(modulepath)}/node_modules`);
+    }
     const result = loadFunction(modulepath);
 
     if(isFunction(result)){


### PR DESCRIPTION
Fixes https://github.com/fission/fission/issues/1635

Steps to reproduce:
1. Create a nodejs environment
2. Create a fission function with the following code
```
exports = async function(context) {
    return {
        status: 200,
        body: "hello, world! "
    };
}
```
3. Check function logs, you will see the logs as described in the https://github.com/fission/fission/issues/1635

Steps to check PR:
1. Create env from this PR code (or use this image rahulbhati/nodejs:v2)
2. Create function using same code as before described in steps to reproduce.
3. Check function logs, no logs of `EEXIST: file already exists, symlink` however, there would be logs in executor as specialization fails and retries several times.


Signed-off-by: therahulbhati <rjbhati009@gmail.com>