### PR TITLE
Add documentation of which environments work in multi-architecture builds.

### DIFF
--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -1,0 +1,6 @@
+# MULTI-ARCH COMPATIBILITY
+
+The following environments have been tested as multi-architecture builds as well as on amd64:
+
+* Nodejs: confirmed working on arm, arm64.
+* Python: confirmed working on arm, arm64.

--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -2,5 +2,6 @@
 
 The following environments have been tested as multi-architecture builds as well as on amd64:
 
-* Nodejs: confirmed working on arm, arm64.
-* Python: confirmed working on arm, arm64.
+* Nodejs : confirmed working on arm, arm64.
+* PHP 7  : confirmed working on arm, arm64.
+* Python : confirmed working on arm, arm64.

--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -2,6 +2,12 @@
 
 The following environments have been tested as multi-architecture builds as well as on amd64:
 
+* Go     : confirmed working (1) on arm, arm64.
 * Nodejs : confirmed working on arm, arm64.
+* Perl   : confirmed working on arm, arm64.
 * PHP 7  : confirmed working on arm, arm64.
 * Python : confirmed working on arm, arm64.
+* Ruby   : confirmed working (2) on arm, arm64.
+
+1. Only when function is supplied in a package; single-file functions do not work.
+2. Requires entrypoint to be explicitly specified, even on single-file functions.


### PR DESCRIPTION
This PR goes along with https://github.com/fission/fission/pull/1891 , recording those environments known or modified to work with different architectures, currently python and nodejs.

(It should probably not be merged until after the above PR is merged and multi-arch fission images are shipped, since "working" in this case, for the builder images, requires that _fission/builder_ contains multi-arch support.)
