### PR TITLE
Modify binary environment for successful multi-arch build.

### DIFF
--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -1,0 +1,6 @@
+# MULTI-ARCH COMPATIBILITY
+
+The following environments have been tested as multi-architecture builds as well as on amd64:
+
+* Nodejs: confirmed working on arm, arm64.
+* Python: confirmed working on arm, arm64.

--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -2,5 +2,9 @@
 
 The following environments have been tested as multi-architecture builds as well as on amd64:
 
+* Binary: confirmed working on arm, arm64 (1).
 * Nodejs: confirmed working on arm, arm64.
 * Python: confirmed working on arm, arm64.
+
+1. Note: only suitable for shell scripts if the cluster contains nodes of multiple architectures; at present, Fission has no way to restrict execution of a function to solely nodes/containers of one particular architecture.
+

--- a/MULTI_ARCH_COMPATIBLITY.md
+++ b/MULTI_ARCH_COMPATIBLITY.md
@@ -2,9 +2,9 @@
 
 The following environments have been tested as multi-architecture builds as well as on amd64:
 
-* Binary: confirmed working on arm, arm64 (1).
+* Binary: confirmed working on arm, arm64 (3).
 * Nodejs: confirmed working on arm, arm64.
 * Python: confirmed working on arm, arm64.
 
-1. Note: only suitable for shell scripts if the cluster contains nodes of multiple architectures; at present, Fission has no way to restrict execution of a function to solely nodes/containers of one particular architecture.
+3. Note: if the cluster contains nodes of multiple architectures, you must create multiple environments limited using PodSpec and nodeSelectors to set the node architectures which particular binary functions execute on. Otherwise only shell scripts will be usable.
 

--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:onbuild
+FROM golang:1.15-alpine
 
 WORKDIR /go
 COPY *.go /go/
 
-RUN GOOS=linux GOARCH=386 go build -o server .
+RUN go build -o server .
 
-FROM alpine:3.5
+FROM alpine:3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
(Includes due to git limitations the first commit of PR #19 .)

Please note the caveat included in the MULTI_ARCH_COMPATIBILITY file that while this enables the use of the binary environment on clusters of any architecture, it does not solve the issue that it will only be suitable for shell scripts on clusters of _mixed_ architecture, as Fission presently does not include any way to tie a function to a given architecture.
