### PR TITLE
Debian buster variant for python & golang

### DIFF
--- a/go/Dockerfile-buster-1.13
+++ b/go/Dockerfile-buster-1.13
@@ -1,0 +1,16 @@
+FROM golang:1.13.15-buster
+
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+ENV GOPATH /usr
+ENV APP	   ${GOPATH}/src/github.com/fission/fission/environments/go
+
+WORKDIR ${APP}
+
+ADD context	    ${APP}/context
+ADD server.go   ${APP}
+
+RUN go get
+RUN go build -a -o /server server.go
+
+ENTRYPOINT ["/server"]
+EXPOSE 8888

--- a/python/Dockerfile-buster
+++ b/python/Dockerfile-buster
@@ -1,0 +1,13 @@
+# offical docker image of python debian buster variant
+FROM python:3.8-buster
+
+RUN apt-get update -y && apt-get install -y python-pip python3-dev libev-dev && pip3 install --upgrade pip 
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN pip3 install -r requirements.txt
+
+COPY . /app
+
+ENTRYPOINT ["python3"]
+CMD ["server.py"]


### PR DESCRIPTION
We already have debian image for Nodejs
Added for golang and python

Addresses fission/fission#1780

Signed-off-by: therahulbhati <rjbhati009@gmail.com>