### PR TITLE
Added release steps for fission environments

### DIFF
--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -55,7 +55,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser
@@ -90,7 +90,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser
@@ -121,7 +121,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser
@@ -155,7 +155,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
 
       uses: Azure/setup-helm@v1    
@@ -190,7 +190,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser
@@ -223,7 +223,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser
@@ -254,7 +254,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yaml
+        filters: .github/workflows/filters/filters.yaml
     - name: Helm
       uses: Azure/setup-helm@v1    
     - name: Kind Clutser

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -77,7 +77,6 @@ jobs:
         command: run
         profile: jvm
         tag: latest
-
     - name: jvm-tests
       run: |
         kind load docker-image jvm-env && ./test_utils/run_test.sh jvm/tests/test_java_env.sh

--- a/.github/workflows/filters/version_filter.yaml
+++ b/.github/workflows/filters/version_filter.yaml
@@ -1,0 +1,24 @@
+binary:
+    - 'binary/envconfig.json'
+jvm-jersey:
+    - 'jvm-jersey/envconfig.json'
+php7: 
+    - 'php7/envconfig.json'  
+dotnet:
+    - 'dotnet/envconfig.json'     
+dotnet20:
+    - 'dotnet20/envconfig.json'     
+go:   
+    - 'go/envconfig.json'     
+jvm:  
+    - 'jvm/envconfig.json'     
+nodejs:
+    - 'nodejs/envconfig.json'
+perl: 
+    - 'perl/envconfig.json'
+python:
+    - 'python/envconfig.json'
+ruby: 
+    - 'ruby/envconfig.json'
+tensorflow-serving:
+    - 'tensorflow-serving/envconfig.json'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/envconfig.json**'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      versions_to_be_released: ${{ steps.release_env.outputs.versions_to_be_released }}
+      release_needed: ${{ steps.release_env.outputs.release_needed }}
+    steps:
+      - name: Checkout the current repo
+        uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: .github/workflows/filters/version_filter.yaml
+      - name: Filter Environments to be released
+        id: release_env
+        run: |
+          python3 hack/release_check.py ${{ steps.filter.outputs.changes }}
+  docker-buildx-push:
+    if: ${{ needs.check.outputs.release_needed == 'True' }}
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.check.outputs.versions_to_be_released) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          use: 'true'
+          buildkitd-flags: --debug
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Trigger Release
+        run: |
+          make verify-builder
+          cd ${{ matrix.env }}
+          TAG=${{ matrix.tag }} make ${{ matrix.image }}-img
+          if [ "${{ matrix.builder}}" != "" ]
+          then
+            cd builder
+            TAG=${{ matrix.tag }} make ${{ matrix.builder }}-img
+          fi

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,4 @@ verify-builder:
 
 $(FISSION_ENVS): verify-builder
 	cd $(subst -envs,,$@)/ && $(MAKE)
+

--- a/binary/envconfig.json
+++ b/binary/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "3.5-alpine", 
+    "image": "binary-env",
+    "builder": "binary-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Fission Binary Environment",

--- a/dotnet/envconfig.json
+++ b/dotnet/envconfig.json
@@ -1,6 +1,7 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "1.1.0", 
+    "image": "dotnet-env",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Dotnet Environment",

--- a/dotnet20/envconfig.json
+++ b/dotnet20/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
-    "runtimeVersion" : "2.0.0", 
+    "version": "1.11.0", 
+    "runtimeVersion" : "2.0.0",
+    "image": "dotnet20-env",    
+    "builder": "dotnet20-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Dotnet 2 Environment",

--- a/go/envconfig.json
+++ b/go/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "1.14", 
+    "image": "go-env-1.14",
+    "builder": "go-builder-1.14",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Go Environment",
@@ -24,8 +26,10 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "1.13", 
+    "image": "go-env-1.13",
+    "builder": "go-builder-1.13",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Go Environment",
@@ -50,8 +54,10 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "1.12", 
+    "image": "go-env",
+    "builder": "go-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Go Environment",
@@ -76,8 +82,38 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
+    "runtimeVersion" : "1.12", 
+    "image": "go-env-1.12",
+    "builder": "go-builder-1.12",
+    "kind": "environment", 
+    "status": "Stable", 
+    "name": "Go Environment",
+    "shortDescription": "Fission Go environment, which uses dynamic loader based on Go plugins.",
+    "readme" : "https://github.com/fission/environments/tree/master/go",
+    "examples" : "https://github.com/fission/environments/tree/master/go/examples",
+    "keywords": [],
+    "icon": "./logo/go-logo-blue.svg",
+    "maintainers": [
+        {
+            "name": "life1347",
+            "link": "https://github.com/life1347"
+        },
+        {
+            "name": "soamvasani",
+            "link": "https://github.com/soamvasani"
+        },
+        {
+            "name": "vishal-biyani",
+            "link": "https://github.com/vishal-biyani"
+        }
+    ]
+},
+{
+    "version": "1.11.0", 
     "runtimeVersion" : "1.11.4", 
+    "image": "go-env-1.11.4",
+    "builder": "go-builder-1.11.4",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Go Environment",

--- a/hack/buildx.sh
+++ b/hack/buildx.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 ## This script needs to be run to start the emulator for multiarch builds
 create_docker_builder() {

--- a/hack/release_check.py
+++ b/hack/release_check.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+import json
+import sys
+import requests
+import subprocess
+
+FISSION_REPO = "fission"
+
+DOCKERHUB_URL = "https://hub.docker.com/v2/repositories/{repo}/{env}/tags/{tag}"
+def check_if_image_exists(image,tag):
+    docker_uri = DOCKERHUB_URL.format(
+        repo=FISSION_REPO,
+        env=image,
+        tag=tag,
+    )
+    resp = requests.get(docker_uri)
+    json_resp = resp.json()
+    if "message" in json_resp and "not found" in json_resp['message']:
+        return False
+    elif "images" in json_resp and len(json_resp["images"]) > 0:
+        return True
+    else:
+        return False
+
+def main(package_list_str):
+    package_list = package_list_str[1:len(package_list_str)-1]
+    package_list = package_list.split(',')
+
+    print(package_list, type(package_list))
+    versions_to_be_released = []
+    for package in package_list:
+        with open(f"{package}/envconfig.json") as f:
+            env_config_json = json.load(f)
+            for env_config in env_config_json:
+                if not check_if_image_exists(env_config['image'],env_config['version']):
+                    versions_to_be_released.append(
+                        {
+                            "image": env_config['image'],
+                            "tag": env_config['version'],
+                            "env": package,
+                            "builder": env_config.get("builder",""), 
+                        }
+                    )
+    json_output = {
+        "include": versions_to_be_released,
+    }
+    print(json_output)
+    release_needed = True if len(versions_to_be_released) > 0 else False
+    subprocess.run(["echo", f"::set-output name=versions_to_be_released::{json.dumps(json_output)}"])
+    subprocess.run(["echo", f"::set-output name=release_needed::{json.dumps(release_needed)}"])
+
+if __name__ == "__main__":
+   main(sys.argv[1])
+
+

--- a/jvm-jersey/envconfig.json
+++ b/jvm-jersey/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0",
+    "version": "1.11.0",
     "runtimeVersion" : "8", 
+    "image": "jvm-jersey-env",
+    "builder": "jvm-jersey-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "JVM Environment",
@@ -17,8 +19,10 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "11", 
+    "image": "jvm-jersey-env-11",
+    "builder": "jvm-jersey-builder-11",
     "kind": "environment", 
     "status": "Stable", 
     "name": "JVM Environment",

--- a/jvm-jersey/pom.xml
+++ b/jvm-jersey/pom.xml
@@ -43,6 +43,11 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-core-asl</artifactId>
+			<version>1.9.13</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/jvm/builder/Makefile
+++ b/jvm/builder/Makefile
@@ -3,4 +3,4 @@
 .PHONY: all
 all: jvm-env-builder-img 
 
-jvm-env-builder-img : Dockerfile
+jvm-builder-img : Dockerfile

--- a/jvm/envconfig.json
+++ b/jvm/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0",
+    "version": "1.11.0",
     "runtimeVersion" : "8", 
+    "image": "jvm-env",
+    "builder": "jvm-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "JVM Environment",

--- a/nodejs/envconfig.json
+++ b/nodejs/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "8.0.0", 
+    "image": "node-env",
+    "builder": "node-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Nodejs Environment",
@@ -25,8 +27,37 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
+    "runtimeVersion" : "8.0.0-debian", 
+    "image": "node-env-debian",
+    "kind": "environment", 
+    "status": "Stable", 
+    "name": "Nodejs Environment",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",  
+    "readme" : "https://github.com/fission/environments/tree/master/nodejs",
+    "examples" : "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "keywords": [],
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "maintainers": [
+        {
+            "name": "life1347",
+            "link": "https://github.com/life1347"
+        },
+        {
+            "name": "soamvasani",
+            "link": "https://github.com/soamvasani"
+        },
+        {
+            "name": "vishal-biyani",
+            "link": "https://github.com/vishal-biyani"
+        }
+    ]
+},
+{
+    "version": "1.11.0", 
     "runtimeVersion" : "12.16", 
+    "image": "node-env-12.16",
+    "builder": "node-builder-12.16",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Nodejs Environment",

--- a/perl/envconfig.json
+++ b/perl/envconfig.json
@@ -1,6 +1,7 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "5", 
+    "image": "perl-env",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Perl Environment",

--- a/php7/envconfig.json
+++ b/php7/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "7", 
+    "image": "php-env",
+    "builder": "php-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "PHP Environment",

--- a/python/Dockerfile-2.7
+++ b/python/Dockerfile-2.7
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
 WORKDIR /app
 

--- a/python/envconfig.json
+++ b/python/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "3.0", 
+    "image": "python-env",
+    "builder": "python-builder",
     "kind": "environment", 
     "status": "alpha", 
     "name": "Python Environment",
@@ -25,8 +27,9 @@
     ]
 },
 {
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "2.7", 
+    "image": "python-env-2.7",
     "kind": "environment", 
     "status": "alpha", 
     "name": "Python Environment",

--- a/ruby/envconfig.json
+++ b/ruby/envconfig.json
@@ -1,6 +1,8 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "2.6.1", 
+    "image": "ruby-env",
+    "builder": "ruby-builder",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Ruby Environment",

--- a/rules.mk
+++ b/rules.mk
@@ -1,5 +1,5 @@
 # Platforms to build in multi-architecture images.
-PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
+PLATFORMS ?= linux/amd64,linux/arm64
 
 # Repository prefix and tag to push multi-architecture images to.
 REPO ?= fission

--- a/tensorflow-serving/Dockerfile
+++ b/tensorflow-serving/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.9.2
+ARG GO_VERSION=1.13
 
 FROM tensorflow/serving as serving
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/tensorflow-serving/envconfig.json
+++ b/tensorflow-serving/envconfig.json
@@ -1,6 +1,7 @@
 [{
-    "version": "1.0.0", 
+    "version": "1.11.0", 
     "runtimeVersion" : "latest", 
+    "image": "tensorflow-serving-env",
     "kind": "environment", 
     "status": "Stable", 
     "name": "Tensorflow Serving Environment",


### PR DESCRIPTION
- Added release pipeline based on the version change in the envconfig.json

REQUIREMENTS:
- This changes requires 2 secrets to be added to the repo for pushing the images to Dockerhub fission registry.
DOCKERHUB_USERNAME - Username of Dockerhub account used to push the images.
DOCKERHUB_TOKEN: Personal access token for the same.

NOTE:
- changed the Go version for tensorflow environment as it was breaking the build.
- Changed base image for python-2.7 env. Changed alpine:3.5 to alpine:3.7.
- Dotnet and dotnet20 envionments are broken as the base image is depricated and doesn't have the image for the platforms we are building. Need to use https://hub.docker.com/_/microsoft-dotnet-sdk/. Also Dotnet 1.* is deprecated by Microsoft. We should move the env to Dotnet3.* something atleast.

 