### PR TITLE
Restrict dotnet env builds to amd64 only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,13 @@
 name: Release
+
 on:
   push:
     branches:
       - master
     paths:
       - '**/envconfig.json**'
+    workflow_dispatch:
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -1,3 +1,5 @@
+PLATFORMS ?= linux/amd64
+
 -include ../rules.mk
 
 .PHONY: all

--- a/dotnet20/Makefile
+++ b/dotnet20/Makefile
@@ -1,3 +1,5 @@
+PLATFORMS ?= linux/amd64
+
 -include ../rules.mk
 
 .PHONY: all

--- a/dotnet20/builder/Makefile
+++ b/dotnet20/builder/Makefile
@@ -1,3 +1,5 @@
+PLATFORMS ?= linux/amd64
+
 -include ../../rules.mk
 
 .PHONY: all


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>