### PR TITLE
node.js: don't install dev dependencies in builder

### DIFF
--- a/nodejs/builder/build.sh
+++ b/nodejs/builder/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd ${SRC_PKG}
-npm install && cp -r ${SRC_PKG} ${DEPLOY_PKG}
+npm install --production && cp -r ${SRC_PKG} ${DEPLOY_PKG}


### PR DESCRIPTION
currently the builder installs dev dependencies, which can make the function potentially huge, this commit removes it