### PR TITLE
binary-env: Waiting for WaitGroup before cmd is released

### DIFF
--- a/binary/server.go
+++ b/binary/server.go
@@ -165,8 +165,8 @@ func (bs *BinaryServer) InvocationHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
 
+	wg.Add(1)
 	go func() {
 		defer func() {
 			stdinPipe.Close()
@@ -207,6 +207,8 @@ func (bs *BinaryServer) InvocationHandler(w http.ResponseWriter, r *http.Request
 			return
 		}
 	}()
+
+	wg.Wait()
 
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
I added a `wg.Wait()` to assure all pipes are read before they are released by `cmd.Wait()` (see [here](https://pkg.go.dev/os/exec#Cmd.StderrPipe)). Since all the other `WaitGroup` logic is already there I assume this simply has been missed.  


fixes #339 