### PR TITLE
Golang environment latest release

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -3,13 +3,13 @@
 .PHONY: all
 all: go-env-img go-env-1.22-img go-env-1.21-img go-env-1.20-img
 
-go-env-img-buildargs := --build-arg GO_VERSION=1.20 --build-arg UBUNTU_VERSION=20.04
+go-env-img-buildargs := --build-arg GO_VERSION=1.20 --build-arg UBUNTU_VERSION=22.04
 
-go-env-1.22-img-buildargs := --build-arg GO_VERSION=1.22 --build-arg UBUNTU_VERSION=20.04
+go-env-1.22-img-buildargs := --build-arg GO_VERSION=1.22 --build-arg UBUNTU_VERSION=22.04
 
-go-env-1.21-img-buildargs := --build-arg GO_VERSION=1.21 --build-arg UBUNTU_VERSION=20.04
+go-env-1.21-img-buildargs := --build-arg GO_VERSION=1.21 --build-arg UBUNTU_VERSION=22.04
 
-go-env-1.20-img-buildargs := --build-arg GO_VERSION=1.20  --build-arg UBUNTU_VERSION=20.04
+go-env-1.20-img-buildargs := --build-arg GO_VERSION=1.20  --build-arg UBUNTU_VERSION=22.04
 
 go-env-img: Dockerfile-1.1x
 

--- a/go/envconfig.json
+++ b/go/envconfig.json
@@ -1,9 +1,9 @@
 [
   {
-    "builder": "go-builder-1.17",
+    "builder": "go-builder-1.22",
     "examples": "https://github.com/fission/environments/tree/master/go/examples",
     "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.17",
+    "image": "go-env-1.22",
     "kind": "environment",
     "maintainers": [
       {
@@ -17,16 +17,16 @@
     ],
     "name": "Go Environment",
     "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.17",
-    "shortDescription": "Fission Go 1.17 environment, which uses dynamic loader based on Go plugins.",
+    "runtimeVersion": "1.22",
+    "shortDescription": "Fission Go 1.22 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.1"
+    "version": "1.32.2"
   },
   {
-    "builder": "go-builder-1.16",
+    "builder": "go-builder-1.21",
     "examples": "https://github.com/fission/environments/tree/master/go/examples",
     "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.16",
+    "image": "go-env-1.21",
     "kind": "environment",
     "maintainers": [
       {
@@ -40,16 +40,16 @@
     ],
     "name": "Go Environment",
     "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.16",
-    "shortDescription": "Fission Go 1.16 environment, which uses dynamic loader based on Go plugins.",
+    "runtimeVersion": "1.21",
+    "shortDescription": "Fission Go 1.21 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.1"
+    "version": "1.32.2"
   },
   {
-    "builder": "go-builder-1.15",
+    "builder": "go-builder-1.20",
     "examples": "https://github.com/fission/environments/tree/master/go/examples",
     "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.15",
+    "image": "go-env-1.20",
     "kind": "environment",
     "maintainers": [
       {
@@ -63,57 +63,10 @@
     ],
     "name": "Go Environment",
     "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.15",
-    "shortDescription": "Fission Go 1.15 environment, which uses dynamic loader based on Go plugins.",
+    "runtimeVersion": "1.20",
+    "shortDescription": "Fission Go 1.20 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.1"
-  },
-  {
-    "builder": "go-builder-1.14",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.14",
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.14",
-    "shortDescription": "Fission Go 1.14 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.32.1"
-  },
-  {
-    "builder": "go-builder-1.13",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.13",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.13",
-    "shortDescription": "Fission Go 1.13 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.32.2"
   },
   {
     "builder": "go-builder",
@@ -134,9 +87,9 @@
     ],
     "name": "Go Environment",
     "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.15",
-    "shortDescription": "Fission Go environment hosts Go 1.15, which uses dynamic loader based on Go plugins.",
+    "runtimeVersion": "1.20",
+    "shortDescription": "Fission Go environment hosts Go 1.20, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.1"
+    "version": "1.32.2"
   }
 ]


### PR DESCRIPTION
Now, we support go-1.20, go-1.21 and go-1.22 only.