### PR TITLE
Update node version

### DIFF
--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -1,12 +1,16 @@
 -include ../rules.mk
 
 .PHONY: all
-all: node-env-debian-img node-env-16-img
+all: node-builder node-env-img node-env-debian-img node-env-22-img
 
-node-env-debian-img-buildargs := --build-arg NODE_BASE_IMG=12.22.7
+node-env-img-buildargs := --build-arg NODE_BASE_IMG=20.16.0-alpine3.20
 
-node-env-16-img-buildargs := --build-arg NODE_BASE_IMG=16.12.0-alpine3.14
+node-env-debian-img-buildargs := --build-arg NODE_BASE_IMG=20.16.0
+
+node-env-22-img-buildargs := --build-arg NODE_BASE_IMG=22.6.0-alpine3.20
+
+node-env-img: Dockerfile
 
 node-env-debian-img: Dockerfile
 
-node-env-16-img: Dockerfile
+node-env-22-img: Dockerfile

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -24,14 +24,14 @@ Build and push the image to the the registry:
 Building runtime image,
 
 ```console
-docker build -t USER/node-env --build-arg NODE_BASE_IMG=16.12.0-alpine3.14 -f Dockerfile . 
+docker build -t USER/node-env --build-arg NODE_BASE_IMG=22.6.0-alpine3.20 -f Dockerfile .
 docker push USER/node-env
 ```
 
 Building builder image,
 
 ```console
-cd builder && docker build -t USER/node-builder --build-arg NODE_BASE_IMG=16.12.0-alpine3.14 -f Dockerfile .
+cd builder && docker build -t USER/node-builder --build-arg NODE_BASE_IMG=22.6.0-alpine3.20 -f Dockerfile .
 docker push USER/go-builder
 ```
 

--- a/nodejs/builder/Makefile
+++ b/nodejs/builder/Makefile
@@ -1,12 +1,16 @@
 -include ../../rules.mk
 
 .PHONY: all
-all: node-builder-debian-img node-builder-16-img
+all: node-builder-debian-img node-builder-img node-builder-22-img
 
-node-builder-debian-img-buildargs := --build-arg NODE_BASE_IMG=12.22.7
+node-builder-debian-img-buildargs := --build-arg NODE_BASE_IMG=22.6.0
 
-node-builder-16-img-buildargs := --build-arg NODE_BASE_IMG=16.12.0-alpine3.14
+node-builder-img-buildargs := --build-arg NODE_BASE_IMG=20.16.0-alpine3.20
+
+node-builder-22-img-buildargs := --build-arg NODE_BASE_IMG=22.6.0-alpine3.20
 
 node-builder-debian-img: Dockerfile
 
-node-builder-16-img: Dockerfile
+node-builder-img: Dockerfile
+
+node-builder-22-img: Dockerfile

--- a/nodejs/envconfig.json
+++ b/nodejs/envconfig.json
@@ -17,16 +17,16 @@
     ],
     "name": "Nodejs Environment",
     "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "12.22.7-debian",
+    "runtimeVersion": "20.16.0-debian",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.3"
   },
   {
-    "builder": "node-builder-16",
+    "builder": "node-builder-22",
     "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
     "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-16",
+    "image": "node-env-22",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -41,9 +41,33 @@
     ],
     "name": "Nodejs Environment",
     "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "16.12.0",
+    "runtimeVersion": "22.6.0",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.3"
+  },
+  {
+    "builder": "node-builder",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.32.3"
   }
 ]


### PR DESCRIPTION
- Updated default node version to 20.16.0 in `fission/node-env` environment.
- Updated current node version to 22.6.0 in `fission/node-env-22` environment.
- Updated node version to 20.16.0 in `fission/node-env-debian` environment.

Fixes: #364 