### PR TITLE
Update Go, Python and Binary environments

### DIFF
--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.22
       - name: Unit test
         run: |
           pushd binary/
@@ -269,7 +269,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.x'
       - name: Unit test
         run: |
           pip3 install virtualenv

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -32,14 +32,15 @@ jobs:
           ./test/local_test.sh
           popd
       - name: Helm
-        uses: Azure/setup-helm@v1
+        uses: Azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.3.4
-      - name: Kind Cluster
+          version: v3.13.0
+      - name: Kind Clutser
         uses: engineerd/setup-kind@v0.5.0
         with:
-          image: kindest/node:v1.21.1
-          version: v0.11.1
+          image: kindest/node:v1.25.16
+          version: v0.23.0
+          config: kind.yaml
       - name: Base Setup
         run: |
           make verify-kind-cluster
@@ -72,14 +73,14 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Helm
-        uses: Azure/setup-helm@v1
+        uses: Azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.3.4
+          version: v3.13.0
       - name: Kind Clutser
         uses: engineerd/setup-kind@v0.5.0
         with:
-          image: kindest/node:v1.21.1
-          version: v0.11.1
+          image: kindest/node:v1.25.16
+          version: v0.23.0
           config: kind.yaml
       - name: Base Setup
         run: |
@@ -268,7 +269,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Unit test
         run: |
           pip3 install virtualenv

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -269,7 +269,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Unit test
         run: |
           pip3 install virtualenv

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -284,14 +284,14 @@ jobs:
           unset RUNTIME_PORT
           popd
       - name: Helm
-        uses: Azure/setup-helm@v1
+        uses: Azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.3.4
+          version: v3.13.0
       - name: Kind Clutser
         uses: engineerd/setup-kind@v0.5.0
         with:
-          image: kindest/node:v1.21.1
-          version: v0.11.1
+          image: kindest/node:v1.25.16
+          version: v0.23.0
           config: kind.yaml
       - name: Base Setup
         run: |

--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.16-alpine
+ARG GO_BASE_IMAGE
+ARG ALPINE_VERSION
+
+FROM golang:${GO_BASE_IMAGE}
 
 WORKDIR /binary
 COPY *.go /binary/
@@ -8,7 +11,7 @@ RUN go mod tidy
 
 RUN go build -o server .
 
-FROM alpine:3.14
+FROM alpine:${ALPINE_VERSION}
 
 WORKDIR /app
 

--- a/binary/Makefile
+++ b/binary/Makefile
@@ -1,7 +1,7 @@
 -include ../rules.mk
 
 .PHONY: all
-all: binary-env-img
+all: binary-builder binary-env-img
 
 binary-env-img-buildargs := --build-arg GO_BASE_IMAGE=1.22-alpine --build-arg ALPINE_VERSION=3.20
 

--- a/binary/Makefile
+++ b/binary/Makefile
@@ -1,6 +1,8 @@
 -include ../rules.mk
 
 .PHONY: all
-all: binary-builder binary-env-img
+all: binary-env-img
+
+binary-env-img-buildargs := --build-arg GO_BASE_IMAGE=1.22-alpine --build-arg ALPINE_VERSION=3.20
 
 binary-env-img: Dockerfile

--- a/binary/builder/Dockerfile
+++ b/binary/builder/Dockerfile
@@ -1,4 +1,8 @@
 ARG BUILDER_IMAGE=fission/builder:latest
 FROM ${BUILDER_IMAGE}
 
+FROM alpine:3.20
+
+COPY --from=0 /builder /builder
+
 ADD build.sh /usr/local/bin/build

--- a/binary/envconfig.json
+++ b/binary/envconfig.json
@@ -18,9 +18,9 @@
     ],
     "name": "Fission Binary Environment",
     "readme": "https://github.com/fission/environments/tree/master/binary",
-    "runtimeVersion": "3.14-alpine",
+    "runtimeVersion": "3.20-alpine",
     "shortDescription": "Fission environment to run any binary",
     "status": "Stable",
-    "version": "1.32.1"
+    "version": "1.32.2"
   }
 ]

--- a/environments.json
+++ b/environments.json
@@ -63,10 +63,10 @@
 ,
 [
   {
-    "builder": "python-builder-3.10",
+    "builder": "python-builder",
     "examples": "https://github.com/fission/environments/tree/master/python/examples",
     "icon": "./logo/Python-logo-notext.png",
-    "image": "python-env-3.10",
+    "image": "python-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -81,10 +81,34 @@
     ],
     "name": "Python Environment",
     "readme": "https://github.com/fission/environments/tree/master/python",
-    "runtimeVersion": "3.10",
+    "runtimeVersion": "3.11",
     "shortDescription": "Fission Python environment based on Flask framework.",
-    "status": "alpha",
-    "version": "1.34.0"
+    "status": "stable",
+    "version": "1.34.1"
+  },
+  {
+    "builder": "python-builder-3.12",
+    "examples": "https://github.com/fission/environments/tree/master/python/examples",
+    "icon": "./logo/Python-logo-notext.png",
+    "image": "python-env-3.12",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Python Environment",
+    "readme": "https://github.com/fission/environments/tree/master/python",
+    "runtimeVersion": "3.12",
+    "shortDescription": "Fission Python environment based on Flask framework.",
+    "status": "stable",
+    "version": "1.34.1"
   }
 ]
 ,
@@ -108,10 +132,10 @@
     ],
     "name": "Fission Binary Environment",
     "readme": "https://github.com/fission/environments/tree/master/binary",
-    "runtimeVersion": "3.14-alpine",
+    "runtimeVersion": "3.20-alpine",
     "shortDescription": "Fission environment to run any binary",
     "status": "Stable",
-    "version": "1.32.1"
+    "version": "1.32.2"
   }
 ]
 ,
@@ -179,10 +203,10 @@
 ,
 [
   {
-    "builder": "go-builder-1.22",
+    "builder": "go-builder",
     "examples": "https://github.com/fission/environments/tree/master/go/examples",
     "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.22",
+    "image": "go-env",
     "kind": "environment",
     "maintainers": [
       {
@@ -199,10 +223,32 @@
     "runtimeVersion": "1.22",
     "shortDescription": "Fission Go 1.22 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.3"
+  },
+  {
+    "builder": "go-builder-1.23",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env-1.23",
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.23",
+    "shortDescription": "Fission Go 1.23 environment, which uses dynamic loader based on Go plugins.",
+    "status": "Stable",
+    "version": "1.32.3"
   }
-]
-,
+],
 [
   {
     "examples": "https://github.com/fission/environments/tree/master/dotnet/examples",
@@ -343,16 +389,16 @@
     ],
     "name": "Nodejs Environment",
     "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "12.22.7-debian",
+    "runtimeVersion": "20.16.0-debian",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.4"
   },
   {
-    "builder": "node-builder-16",
+    "builder": "node-builder-22",
     "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
     "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-16",
+    "image": "node-env-22",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -367,10 +413,34 @@
     ],
     "name": "Nodejs Environment",
     "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "16.12.0",
+    "runtimeVersion": "22.6.0",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.4"
+  },
+  {
+    "builder": "node-builder",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.32.4"
   }
 ]
 

--- a/environments.json
+++ b/environments.json
@@ -85,30 +85,6 @@
     "shortDescription": "Fission Python environment based on Flask framework.",
     "status": "stable",
     "version": "1.34.1"
-  },
-  {
-    "builder": "python-builder-3.12",
-    "examples": "https://github.com/fission/environments/tree/master/python/examples",
-    "icon": "./logo/Python-logo-notext.png",
-    "image": "python-env-3.12",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Python Environment",
-    "readme": "https://github.com/fission/environments/tree/master/python",
-    "runtimeVersion": "3.12",
-    "shortDescription": "Fission Python environment based on Flask framework.",
-    "status": "stable",
-    "version": "1.34.1"
   }
 ]
 ,

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,9 +1,13 @@
 -include ../rules.mk
 
 .PHONY: all
-all: go-env-1.22-img
+all: go-env-img go-env-1.23-img
 
-go-env-1.22-img-buildargs := --build-arg GO_VERSION=1.22 --build-arg UBUNTU_VERSION=22.04
+go-env-img-buildargs := --build-arg GO_VERSION=1.22 --build-arg UBUNTU_VERSION=22.04
 
-go-env-1.22-img: Dockerfile-1.1x
+go-env-1.23-img-buildargs := --build-arg GO_VERSION=1.23 --build-arg UBUNTU_VERSION=22.04
+
+go-env-img: Dockerfile-1.1x
+
+go-env-1.23-img: Dockerfile-1.1x
 

--- a/go/builder/Makefile
+++ b/go/builder/Makefile
@@ -1,8 +1,12 @@
 -include ../../rules.mk
 
 .PHONY: all
-all: go-builder-1.22-img 
+all: go-builder-img go-builder-1.23-img
 
-go-builder-1.22-img-buildargs := --build-arg GO_VERSION=1.22
+go-builder-img-buildargs := --build-arg GO_VERSION=1.22
 
-go-builder-1.22-img: Dockerfile-1.1x
+go-builder-1.23-img-buildargs := --build-arg GO_VERSION=1.23
+
+go-builder-img: Dockerfile-1.1x
+
+go-builder-1.23-img: Dockerfile-1.1x

--- a/go/envconfig.json
+++ b/go/envconfig.json
@@ -1,9 +1,9 @@
 [
   {
-    "builder": "go-builder-1.22",
+    "builder": "go-builder",
     "examples": "https://github.com/fission/environments/tree/master/go/examples",
     "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.22",
+    "image": "go-env",
     "kind": "environment",
     "maintainers": [
       {
@@ -20,6 +20,29 @@
     "runtimeVersion": "1.22",
     "shortDescription": "Fission Go 1.22 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.32.3"
+  },
+  {
+    "builder": "go-builder-1.23",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env-1.23",
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.23",
+    "shortDescription": "Fission Go 1.23 environment, which uses dynamic loader based on Go plugins.",
+    "status": "Stable",
+    "version": "1.32.3"
   }
 ]

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,8 +1,12 @@
 -include ../rules.mk
 
 .PHONY: all
-all: python-env-3.10-img
+all: python-env-img python-env-3.12-img
 
-python-env-3.10-img-buildargs := --build-arg PY_BASE_IMG=3.10-alpine
+python-env-img-buildargs := --build-arg PY_BASE_IMG=3.11-alpine
 
-python-env-3.10-img: Dockerfile
+python-env-3.12-img-buildargs := --build-arg PY_BASE_IMG=3.12-alpine
+
+python-env-img: Dockerfile
+
+python-env-3.12-img: Dockerfile

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,12 +1,8 @@
 -include ../rules.mk
 
 .PHONY: all
-all: python-env-img python-env-3.12-img
+all: python-env-img
 
 python-env-img-buildargs := --build-arg PY_BASE_IMG=3.11-alpine
 
-python-env-3.12-img-buildargs := --build-arg PY_BASE_IMG=3.12-alpine
-
 python-env-img: Dockerfile
-
-python-env-3.12-img: Dockerfile

--- a/python/builder/Makefile
+++ b/python/builder/Makefile
@@ -1,8 +1,12 @@
 -include ../../rules.mk
 
 .PHONY: all
-all: python-builder-3.10-img
+all: python-builder-img python-builder-3.12-img
 
-python-builder-3.10-img-buildargs := --build-arg PY_BASE_IMG=3.10-alpine
+python-builder-img-buildargs := --build-arg PY_BASE_IMG=3.11-alpine
 
-python-builder-3.10-img: Dockerfile
+python-builder-3.12-img-buildargs := --build-arg PY_BASE_IMG=3.12-alpine
+
+python-builder-img: Dockerfile
+
+python-builder-3.12-img: Dockerfile

--- a/python/builder/Makefile
+++ b/python/builder/Makefile
@@ -1,12 +1,8 @@
 -include ../../rules.mk
 
 .PHONY: all
-all: python-builder-img python-builder-3.12-img
+all: python-builder-img
 
 python-builder-img-buildargs := --build-arg PY_BASE_IMG=3.11-alpine
 
-python-builder-3.12-img-buildargs := --build-arg PY_BASE_IMG=3.12-alpine
-
 python-builder-img: Dockerfile
-
-python-builder-3.12-img: Dockerfile

--- a/python/envconfig.json
+++ b/python/envconfig.json
@@ -1,9 +1,9 @@
 [
   {
-    "builder": "python-builder-3.10",
+    "builder": "python-builder",
     "examples": "https://github.com/fission/environments/tree/master/python/examples",
     "icon": "./logo/Python-logo-notext.png",
-    "image": "python-env-3.10",
+    "image": "python-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -18,9 +18,33 @@
     ],
     "name": "Python Environment",
     "readme": "https://github.com/fission/environments/tree/master/python",
-    "runtimeVersion": "3.10",
+    "runtimeVersion": "3.11",
     "shortDescription": "Fission Python environment based on Flask framework.",
-    "status": "alpha",
-    "version": "1.34.0"
+    "status": "stable",
+    "version": "1.34.1"
+  },
+  {
+    "builder": "python-builder-3.12",
+    "examples": "https://github.com/fission/environments/tree/master/python/examples",
+    "icon": "./logo/Python-logo-notext.png",
+    "image": "python-env-3.12",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Python Environment",
+    "readme": "https://github.com/fission/environments/tree/master/python",
+    "runtimeVersion": "3.12",
+    "shortDescription": "Fission Python environment based on Flask framework.",
+    "status": "stable",
+    "version": "1.34.1"
   }
 ]

--- a/python/envconfig.json
+++ b/python/envconfig.json
@@ -22,29 +22,5 @@
     "shortDescription": "Fission Python environment based on Flask framework.",
     "status": "stable",
     "version": "1.34.1"
-  },
-  {
-    "builder": "python-builder-3.12",
-    "examples": "https://github.com/fission/environments/tree/master/python/examples",
-    "icon": "./logo/Python-logo-notext.png",
-    "image": "python-env-3.12",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Python Environment",
-    "readme": "https://github.com/fission/environments/tree/master/python",
-    "runtimeVersion": "3.12",
-    "shortDescription": "Fission Python environment based on Flask framework.",
-    "status": "stable",
-    "version": "1.34.1"
   }
 ]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,9 +5,9 @@ chardet==4.0.0
 charset-normalizer==2.0.7
 click==8.0.3
 Flask==2.1.1
-gevent==21.12.0
+gevent==22.10.2
 gevent-ws==2.1.0
-greenlet==1.1.2
+greenlet==3.0.2
 hiredis==2.0.0
 httplib2==0.20.1
 idna==3.3

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,14 +48,14 @@ profiles:
       docker:
         dockerfile: Dockerfile-1.1x
         buildArgs:
-          GO_VERSION: "1.16"
-          UBUNTU_VERSION: "20.04"
+          GO_VERSION: "1.22"
+          UBUNTU_VERSION: "22.04"
     - image: go-builder
       context: go/builder/
       docker:
         dockerfile: Dockerfile-1.1x
         buildArgs:
-          GO_VERSION: "1.16"
+          GO_VERSION: "1.22"
 - name: jvm
   build:
     artifacts:
@@ -111,13 +111,13 @@ profiles:
       docker:
         dockerfile: Dockerfile
         buildArgs:
-          PY_BASE_IMG: "3.7-alpine"
+          PY_BASE_IMG: "3.11-alpine"
     - image: python-builder
       context: python/builder/
       docker:
         dockerfile: Dockerfile
         buildArgs:
-          PY_BASE_IMG: "3.7-alpine"
+          PY_BASE_IMG: "3.11-alpine"
 - name: ruby
   build:
     artifacts:
@@ -139,6 +139,9 @@ profiles:
       context: binary/
       docker:
         dockerfile: Dockerfile
+        buildArgs:
+          GO_BASE_IMAGE: "1.22-alpine"
+          ALPINE_VERSION: "3.20"
     - image: binary-builder
       context: binary/builder/
       docker:


### PR DESCRIPTION
Updated Python default env version to Python-3.11 and current env to Python-3.12.
Updated Go default env version to 1.22 and current env to Go-1.23. 
Updated binary environment to use Go-1.22 base image.
Updated environments.json file.