### PR TITLE
fix: correct build context for dotnet8-builder Docker image

### DIFF
--- a/dotnet8/Makefile
+++ b/dotnet8/Makefile
@@ -11,5 +11,5 @@ dotnet8-env-img: Dockerfile
 	docker build --platform=$(PLATFORMS) -t $(REPO)/dotnet8-env:$(TAG) -f $< .
 
 dotnet8-builder-img: builder/Dockerfile
-	@echo === Building image $(REPO)/dotnet8-builder:$(TAG) using context $(CURDIR)/builder and dockerfile $<
-	docker build --platform=$(PLATFORMS) -t $(REPO)/dotnet8-builder:$(TAG) -f $< builder/
+	@echo === Building image $(REPO)/dotnet8-builder:$(TAG) using context $(CURDIR) and dockerfile $<
+	docker build --platform=$(PLATFORMS) -t $(REPO)/dotnet8-builder:$(TAG) -f $< .

--- a/dotnet8/builder/Makefile
+++ b/dotnet8/builder/Makefile
@@ -5,4 +5,7 @@ PLATFORMS ?= linux/amd64,linux/arm64
 .PHONY: all
 all: dotnet8-builder-img
 
-dotnet8-builder-img: Dockerfile 
+# Override the rule to use parent directory as context
+dotnet8-builder-img: Dockerfile
+	@echo === Building image $(REPO)/dotnet8-builder:$(TAG) using parent directory as context
+	cd .. && docker buildx build --platform=$(PLATFORMS) -t $(REPO)/dotnet8-builder:$(TAG) $(DOCKER_FLAGS) -f builder/Dockerfile . 


### PR DESCRIPTION
The dotnet8 builder Dockerfile requires files from both the builder/ subdirectory and the parent dotnet8/ directory (Fission.DotNet.Common source files). This fix updates both Makefiles to use the parent dotnet8 directory as the Docker build context, matching the approach used by dotnet8-env-img.

Changes:
- dotnet8/builder/Makefile: Use parent directory as build context
- dotnet8/Makefile: Use parent directory as build context for builder image

This resolves the GitHub Actions build failure where files were not found.