### PR TITLE
feat: support response streaming on node env

### DIFF
--- a/nodejs/server.js
+++ b/nodejs/server.js
@@ -6,6 +6,7 @@ const pino = require("pino");
 const { createServer } = require("http");
 const { WebSocketServer } = require("ws");
 const minimist = require("minimist");
+const { Readable } = require("node:stream");
 
 const DEFAULT_TIMEOUT = 60000;
 
@@ -358,7 +359,12 @@ app.use((req, res) => {
         res.set(name, headers[name]);
       }
     }
-    res.status(status).send(body);
+    res.status(status);
+    if (body instanceof Readable) {
+      body.pipe(res);
+    } else {
+      res.send(body);
+    }
   };
 
   //


### PR DESCRIPTION
With this PR the node environment now supports response streaming by returning a Readable as the body from the fission function.

This environment can be tried with:
```sh
fission environment create --name nodejs-streaming --image ghcr.io/a-safe-digital/node-streaming-env:0.1.3
```