### PR TITLE
ci: upgrade to Fission v1.25.0 and modernize workflows

### DIFF
--- a/.github/actions/setup-cluster/action.yml
+++ b/.github/actions/setup-cluster/action.yml
@@ -4,15 +4,15 @@ inputs:
   kind-node-image:
     description: 'Kind node image to use'
     required: false
-    default: 'kindest/node:v1.27.16'
+    default: 'kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256'
   kind-version:
     description: 'Kind version to use'
     required: false
-    default: 'v0.23.0'
+    default: 'v0.32.0'
   helm-version:
     description: 'Helm version to use'
     required: false
-    default: 'v3.18.4'
+    default: 'v3.21.0'
   kind-config:
     description: 'Kind config file'
     required: false
@@ -20,17 +20,17 @@ inputs:
   fission-cli-version:
     description: 'Fission CLI version to install'
     required: false
-    default: 'v1.21.0'
+    default: 'v1.25.0'
 runs:
   using: "composite"
   steps:
     - name: Helm
-      uses: Azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
         version: ${{ inputs.helm-version }}
 
     - name: Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
+      uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1 # v0.6.2
       with:
         image: ${{ inputs.kind-node-image }}
         version: ${{ inputs.kind-version }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,16 +17,22 @@ The workflow uses two main composite actions to reduce duplication:
 1. **setup-cluster**: Sets up the complete infrastructure needed for testing (Helm, Kind, Fission CLI) and performs base Fission setup steps
 2. **collect-fission-dump**: Collects and archives Fission dumps on failure
 
-## Environment Variables
+## Version Pins
 
-All version pins are centralized in the `env` section of the main workflow file:
+Tooling version pins live in the input defaults of `actions/setup-cluster/action.yml`:
 
-- `KIND_NODE_IMAGE`: Kind node image version
-- `KIND_VERSION`: Kind tool version
-- `HELM_VERSION`: Helm version
-- `FISSION_CLI_VERSION`: Fission CLI version
-- `KIND_CONFIG`: Path to Kind configuration
-- `FISSION_VERSION`: Fission version
+- `kind-node-image`: Kind node image version
+- `kind-version`: Kind tool version
+- `helm-version`: Helm version
+- `fission-cli-version`: Fission CLI version
+- `kind-config`: Path to Kind configuration
+
+The Fission version is pinned in several places that must be kept in sync when upgrading:
+
+- `FISSION_VERSION` in the `env` section of `environment.yaml` (used by the Makefile)
+- `FISSION_VERSION` in the root `rules.mk`
+- `fission-cli-version` default in `actions/setup-cluster/action.yml`
+- The Helm `remoteChart` URL in the root `skaffold.yaml`
 
 ## Usage
 

--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -3,9 +3,13 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Only FISSION_VERSION is needed for the Makefile
-  FISSION_VERSION: v1.21.0
+  FISSION_VERSION: v1.25.0
 
 jobs:
   # Job to run change detection
@@ -47,6 +51,7 @@ jobs:
         run: ./test_utils/run_test.sh ./binary/test/test_binary_env.sh
       - name: Collect Fission Dump
         uses: ./.github/actions/collect-fission-dump
+        if: ${{ failure() }}
         with:
           workflow-name: binary
   go:
@@ -67,19 +72,16 @@ jobs:
         run: ./test_utils/run_test.sh ./go/tests/test_go_env.sh
       - name: Collect Fission Dump
         uses: ./.github/actions/collect-fission-dump
+        if: ${{ failure() }}
         with:
           workflow-name: go
   jvm:
     runs-on: ubuntu-latest
     needs: check
-    if: contains( needs.check.outputs.packages, 'jvm' )
+    if: contains( needs.check.outputs.packages, '"jvm"' )
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: .github/workflows/filters/filters.yaml
       - name: Setup Fission Environment
         uses: ./.github/actions/setup-cluster
       - name: jvm
@@ -89,6 +91,27 @@ jobs:
           make router-port-forward
       - name: jvm-tests
         run: ./test_utils/run_test.sh jvm/tests/test_java_env.sh
+      - name: Collect Fission Dump
+        uses: ./.github/actions/collect-fission-dump
+        if: ${{ failure() }}
+        with:
+          workflow-name: jvm
+  jvm-jersey:
+    runs-on: ubuntu-latest
+    needs: check
+    if: contains( needs.check.outputs.packages, 'jvm-jersey' )
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Fission Environment
+        uses: ./.github/actions/setup-cluster
+      - name: jvm-jersey
+        run: SKAFFOLD_PROFILE=jvm-jersey make skaffold-run
+      - name: Collect Fission Dump
+        uses: ./.github/actions/collect-fission-dump
+        if: ${{ failure() }}
+        with:
+          workflow-name: jvm-jersey
   nodejs:
     runs-on: ubuntu-latest
     needs: check
@@ -160,11 +183,11 @@ jobs:
   python:
     runs-on: ubuntu-latest
     needs: check
-    if: contains( needs.check.outputs, 'python' )
+    if: contains( needs.check.outputs.packages, '"python"' )
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Unit test
@@ -202,7 +225,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Unit test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
       release_needed: ${{ steps.release_env.outputs.release_needed }}
     steps:
       - name: Checkout the current repo
-        uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: .github/workflows/filters/version_filter.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python3 hack/release_check.py ${{ steps.filter.outputs.changes }}
   docker-buildx-push:
-    if: ${{ needs.check.outputs.release_needed == 'True' }}
+    if: ${{ needs.check.outputs.release_needed == 'true' }}
     needs: check
     strategy:
       fail-fast: false
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           version: latest
           use: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ environments-ui/server.js
 node_modules
 **/node_modules/**
 *.DS_Store
+__pycache__/
+*.pyc

--- a/hack/release_check.py
+++ b/hack/release_check.py
@@ -1,30 +1,46 @@
 #!/usr/bin/python3
 
 import json
+import os
 import sys
 import requests
-import subprocess
 
-FISSION_REPO = "ghcr.io/fission"
+GHCR_ORG = "fission"
 
-GHCR_URL = "https://ghcr.io/v2/{repo}/{env}/tags/list"
+GHCR_TOKEN_URL = "https://ghcr.io/token?scope=repository:{org}/{env}:pull"
+GHCR_URL = "https://ghcr.io/v2/{org}/{env}/tags/list"
 def check_if_image_exists(image,tag):
-    docker_uri = GHCR_URL.format(
-        repo=FISSION_REPO,
-        env=image
-    )
-    resp = requests.get(docker_uri)
-    json_resp = resp.json()
-    if "message" in json_resp and "not found" in json_resp['message']:
+    # GHCR v2 API needs a bearer token even for public images;
+    # an anonymous token is sufficient for pull scope.
+    token_resp = requests.get(GHCR_TOKEN_URL.format(org=GHCR_ORG, env=image), timeout=30)
+    token_resp.raise_for_status()
+    token = token_resp.json().get("token")
+    if not token:
+        raise RuntimeError(f"GHCR token response missing 'token' for image '{image}': {token_resp.text[:200]}")
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.get(GHCR_URL.format(org=GHCR_ORG, env=image), headers=headers, timeout=30)
+    if resp.status_code == 200:
+        return tag in resp.json().get("tags", [])
+    if resp.status_code == 404:
+        # Repository does not exist yet -> release needed.
         return False
-    elif "tags" in json_resp and tag in json_resp["images"]:
-        return True
-    else:
-        return False
+    # Auth/rate-limit/5xx errors must fail the job (fail-closed) rather
+    # than masquerade as "image absent" and trigger spurious re-releases.
+    resp.raise_for_status()
+    raise RuntimeError(f"Unexpected GHCR response for image '{image}': {resp.status_code} {resp.text[:200]}")
+
+def set_output(name, value):
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        # Local/dry-run fallback: print instead of failing with a KeyError.
+        print(f"{name}={value}")
+        return
+    with open(output_path, "a") as f:
+        f.write(f"{name}={value}\n")
 
 def main(package_list_str):
-    package_list = package_list_str[1:len(package_list_str)-1]
-    package_list = package_list.split(',')
+    package_list = package_list_str.strip("[]")
+    package_list = [p.strip().strip('"') for p in package_list.split(',') if p.strip()]
 
     print(package_list, type(package_list))
     versions_to_be_released = []
@@ -38,7 +54,7 @@ def main(package_list_str):
                             "image": env_config['image'],
                             "tag": env_config['version'],
                             "env": package,
-                            "builder": env_config.get("builder",""), 
+                            "builder": env_config.get("builder",""),
                         }
                     )
     json_output = {
@@ -46,10 +62,9 @@ def main(package_list_str):
     }
     print(json_output)
     release_needed = True if len(versions_to_be_released) > 0 else False
-    subprocess.run(["echo", f"::set-output name=versions_to_be_released::{json.dumps(json_output)}"])
-    subprocess.run(["echo", f"::set-output name=release_needed::{json.dumps(release_needed)}"])
+    set_output("versions_to_be_released", json.dumps(json_output))
+    # release.yaml gates on `release_needed == 'true'`.
+    set_output("release_needed", "true" if release_needed else "false")
 
 if __name__ == "__main__":
    main(sys.argv[1])
-
-

--- a/rules.mk
+++ b/rules.mk
@@ -5,7 +5,7 @@ PLATFORMS ?= linux/amd64,linux/arm64
 REPO ?= ghcr.io/fission
 TAG ?= dev
 DOCKER_FLAGS ?= --push --progress plain
-FISSION_VERSION ?= v1.21.0
+FISSION_VERSION ?= v1.25.0
 SKAFFOLD_PROFILE ?= kind
 
 %-img:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ deploy:
   helm:
     releases:
     - name: fission
-      remoteChart: https://github.com/fission/fission-charts/releases/download/fission-all-v1.21.0/fission-all-v1.21.0.tgz
+      remoteChart: https://github.com/fission/fission-charts/releases/download/fission-all-1.25.0/fission-all-1.25.0.tgz
       namespace: fission
       setValues:
         analytics: "false"


### PR DESCRIPTION
## What

First of a series of PRs updating all environments to latest secure versions. This one touches only CI/build infra (no env directories), so it should merge first.

### Fission v1.25.0
- `FISSION_VERSION` v1.21.0 → v1.25.0 in `rules.mk`, workflow `env`, `setup-cluster` action default.
- skaffold helm `remoteChart` → `fission-all-1.25.0` (note: new chart release tags drop the `v` prefix; URL verified live).

### Cluster tooling
- kind v0.23.0 → v0.32.0, `kindest/node` v1.27.16 (k8s 1.27 is EOL) → v1.34.8 digest-pinned — matches the kind versions fission v1.25.0 itself tests against.
- helm v3.18.4 → v3.21.0.
- `Azure/setup-helm` → v4.3.1, `engineerd/setup-kind` → v0.6.2 (both SHA-pinned), `actions/setup-python` v2 → v6, `checkout`/`paths-filter`/`qemu`/`buildx` bumps in `release.yaml`.

### Workflow fixes & optimizations
- `concurrency` + `cancel-in-progress` so superseded PR pushes don't burn runners.
- Fixed python job gate: `contains( needs.check.outputs, 'python' )` was missing `.packages`. Also switched python/jvm gates to exact-match (`'"jvm"'`) so `python-fastapi`/`jvm-jersey` changes no longer cross-trigger the python/jvm jobs.
- Added the missing `jvm-jersey` job (a path filter existed but no job consumed it — jvm-jersey changes were never CI-built).
- jvm job: removed redundant `paths-filter` step, added `Collect Fission Dump` on failure.
- `Collect Fission Dump` now runs only on failure in binary/go jobs (previously ran unconditionally).

### Release pipeline repair (`hack/release_check.py`)
The release gate has been silently broken — evidence: `python-env` `envconfig.json` says `1.34.3` but GHCR only has `1.34.2`. Three bugs fixed:
1. GHCR `tags/list` requires a bearer token (anonymous token works for public images); the unauthenticated call always 401ed.
2. `tag in json_resp["images"]` — the `images` key never existed (should be `tags`), so the check could never return "already published".
3. `::set-output` workflow command has been removed by GitHub; now writes to `$GITHUB_OUTPUT`. Also `release_needed` now emits/gates on `'true'` consistently (previously `json.dumps` emitted `true` but the workflow compared against `'True'`).

Error handling is now fail-closed: auth/rate-limit/5xx responses raise and fail the check job instead of being misread as "image absent" (which previously re-pushed every image including `latest`).

Verified by running the script live against GHCR: correctly detects published `go-env` tags and the unpublished `python-env:1.34.3`.

**Note:** once this merges, the next release run will publish any envconfig versions that were never released due to the broken gate (e.g. `python-env:1.34.3`).

## Follow-up suggestions (not in this PR)
- Add `dependabot.yml` ecosystem for `github-actions`.
- Docker layer caching (`type=gha`) for CI image builds.
- Functional smoke tests for build-only envs (perl/php7/ruby/tensorflow/jvm-jersey).

## Verification
- YAML validated; `release_check.py` exercised live against GHCR (both bracket-quoted and plain package-list formats).
- This PR touches no env dirs, so no env jobs trigger; the workflow changes take effect for subsequent env PRs in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)