### PR TITLE
fix(jvm): restore Java env build by installing fission-java-core from source

### DIFF
--- a/.github/workflows/environment.yaml
+++ b/.github/workflows/environment.yaml
@@ -72,14 +72,10 @@ jobs:
   jvm:
     runs-on: ubuntu-latest
     needs: check
-    if: contains( needs.check.outputs.packages, 'jvm' )
+    if: contains( needs.check.outputs.packages, '"jvm"' )
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: .github/workflows/filters/filters.yaml
       - name: Setup Fission Environment
         uses: ./.github/actions/setup-cluster
       - name: jvm
@@ -89,6 +85,11 @@ jobs:
           make router-port-forward
       - name: jvm-tests
         run: ./test_utils/run_test.sh jvm/tests/test_java_env.sh
+      - name: Collect Fission Dump
+        uses: ./.github/actions/collect-fission-dump
+        if: ${{ failure() }}
+        with:
+          workflow-name: jvm
   nodejs:
     runs-on: ubuntu-latest
     needs: check

--- a/environments.json
+++ b/environments.json
@@ -1,63 +1,151 @@
 [
 [
   {
-    "builder": "jvm-jersey-builder-11",
-    "examples": "https://github.com/fission/environments/tree/master/jvm-jersey/examples",
-    "icon": "./logo/Java-Logo.png",
-    "image": "jvm-jersey-env-11",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env-debian",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "JVM Environment",
-    "readme": "https://github.com/fission/environments/tree/master/jvm-jersey",
-    "runtimeVersion": "11",
-    "shortDescription": "JVM environment based on Jersey RESTful Web Services framework",
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0-debian",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.33"
+  },
+  {
+    "builder": "node-builder-22",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env-22",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "22.6.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.33"
+  },
+  {
+    "builder": "node-builder",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.33"
   }
 ]
 ,
 [
   {
-    "builder": "ruby-builder",
-    "examples": "https://github.com/fission/environments/tree/master/ruby/examples",
-    "icon": "./logo/Ruby_logo.svg",
-    "image": "ruby-env",
-    "keywords": [],
+    "builder": "go-builder",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env",
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Ruby Environment",
-    "readme": "https://github.com/fission/environments/tree/master/ruby",
-    "runtimeVersion": "2.6.1",
-    "shortDescription": "Ruby environment with WEBrick library",
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.25",
+    "shortDescription": "Fission Go 1.25 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.33.0"
+  },
+  {
+    "builder": "go-builder-1.25",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env-1.25",
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.25",
+    "shortDescription": "Fission Go 1.25 environment, which uses dynamic loader based on Go plugins.",
+    "status": "Stable",
+    "version": "1.33.0"
+  }
+]
+,
+[
+  {
+    "builder": "python-fastapi-builder",
+    "examples": "https://github.com/fission/environments/tree/master/python/examples",
+    "icon": "./logo/Python-logo-notext.png",
+    "image": "python-fastapi-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Python FastAPI Environment",
+    "readme": "https://github.com/fission/environments/tree/master/python",
+    "runtimeVersion": "3.11",
+    "shortDescription": "Fission Python environment based on FastAPI framework.",
+    "status": "stable",
+    "version": "1.34.2"
   }
 ]
 ,
@@ -84,34 +172,68 @@
     "runtimeVersion": "3.11",
     "shortDescription": "Fission Python environment based on Flask framework.",
     "status": "stable",
-    "version": "1.34.1"
+    "version": "1.34.3"
   }
 ]
 ,
 [
   {
-    "builder": "binary-builder",
-    "examples": "https://github.com/fission/environments/tree/master/binary/examples",
-    "icon": "./logo/full_colored_dark.svg",
-    "image": "binary-env",
+    "examples": "https://github.com/fission/environments/tree/master/perl/examples",
+    "icon": "./logo/perl-programming-language.svg",
+    "image": "perl-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Fission Binary Environment",
-    "readme": "https://github.com/fission/environments/tree/master/binary",
-    "runtimeVersion": "3.20-alpine",
-    "shortDescription": "Fission environment to run any binary",
+    "name": "Perl Environment",
+    "readme": "https://github.com/fission/environments/tree/master/perl",
+    "runtimeVersion": "5",
+    "shortDescription": "Perl environment based on the Dancer2 framework",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.31.1"
+  }
+]
+,
+[
+  {
+    "builder": "jvm-builder",
+    "examples": "https://github.com/fission/environments/tree/master/jvm/examples",
+    "icon": "./logo/Java-Logo.png",
+    "image": "jvm-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "JVM Environment",
+    "readme": "https://github.com/fission/environments/tree/master/jvm",
+    "runtimeVersion": "25",
+    "shortDescription": "JVM environment based on Spring Boot server",
+    "status": "Stable",
+    "version": "1.32.0"
   }
 ]
 ,
@@ -148,85 +270,6 @@
 ,
 [
   {
-    "builder": "dotnet20-builder",
-    "examples": "https://github.com/fission/environments/tree/master/dotnet20/examples",
-    "icon": "./logo/logo_NETcore.svg",
-    "image": "dotnet20-env",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Dotnet 2 Environment",
-    "readme": "https://github.com/fission/environments/tree/master/dotnet20",
-    "runtimeVersion": "2.0.0",
-    "shortDescription": "Fission Dotnet 2.0.0 runtime uses Kestrel with Nancy to host the internal web server and uses Roslyn to compile the uploaded code.",
-    "status": "Stable",
-    "version": "1.31.1"
-  }
-]
-,
-[
-  {
-    "builder": "go-builder",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env",
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.22",
-    "shortDescription": "Fission Go 1.22 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.32.3"
-  },
-  {
-    "builder": "go-builder-1.23",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.23",
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.23",
-    "shortDescription": "Fission Go 1.23 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.32.3"
-  }
-],
-[
-  {
     "examples": "https://github.com/fission/environments/tree/master/dotnet/examples",
     "icon": "./logo/dotnet-logo.svg",
     "image": "dotnet-env",
@@ -253,12 +296,14 @@
     "status": "Stable",
     "version": "1.31.1"
   }
-],[
+]
+,
+[
   {
-    "builder": "dotnet8-builder",
-    "examples": "https://github.com/fission/environments/tree/master/dotnet8/examples",
-    "icon": "./logo/logo_NETcore.svg",
-    "image": "dotnet8-env",
+    "builder": "jvm-jersey-builder-22",
+    "examples": "https://github.com/fission/environments/tree/master/jvm-jersey/examples",
+    "icon": "./logo/Java-Logo.png",
+    "image": "jvm-jersey-env-22",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -275,42 +320,39 @@
         "name": "vishal-biyani"
       }
     ],
-    "name": "Dotnet 8 Environment",
-    "readme": "https://github.com/fission/environments/tree/master/dotnet8",
-    "runtimeVersion": "8.0.18",
-    "shortDescription": "Fission Dotnet 8.0.18 runtime w/ .NET SDK 8.0.412 and ASP.NET Core 8.0.18",
+    "name": "JVM Environment",
+    "readme": "https://github.com/fission/environments/tree/master/jvm-jersey",
+    "runtimeVersion": "22",
+    "shortDescription": "JVM environment based on Jersey RESTful Web Services framework",
     "status": "Stable",
-    "version": "1.0.0"
+    "version": "1.31.2"
   }
 ]
 ,
 [
   {
-    "examples": "https://github.com/fission/environments/tree/master/perl/examples",
-    "icon": "./logo/perl-programming-language.svg",
-    "image": "perl-env",
+    "builder": "binary-builder",
+    "examples": "https://github.com/fission/environments/tree/master/binary/examples",
+    "icon": "./logo/full_colored_dark.svg",
+    "image": "binary-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Perl Environment",
-    "readme": "https://github.com/fission/environments/tree/master/perl",
-    "runtimeVersion": "5",
-    "shortDescription": "Perl environment based on the Dancer2 framework",
+    "name": "Fission Binary Environment",
+    "readme": "https://github.com/fission/environments/tree/master/binary",
+    "runtimeVersion": "3.20-alpine",
+    "shortDescription": "Fission environment to run any binary",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.32.3"
   }
 ]
 ,
@@ -346,10 +388,10 @@
 ,
 [
   {
-    "builder": "jvm-builder",
-    "examples": "https://github.com/fission/environments/tree/master/jvm/examples",
-    "icon": "./logo/Java-Logo.png",
-    "image": "jvm-env",
+    "builder": "dotnet20-builder",
+    "examples": "https://github.com/fission/environments/tree/master/dotnet20/examples",
+    "icon": "./logo/logo_NETcore.svg",
+    "image": "dotnet20-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -366,10 +408,10 @@
         "name": "vishal-biyani"
       }
     ],
-    "name": "JVM Environment",
-    "readme": "https://github.com/fission/environments/tree/master/jvm",
-    "runtimeVersion": "8",
-    "shortDescription": "JVM environment based on Spring Boot server",
+    "name": "Dotnet 2 Environment",
+    "readme": "https://github.com/fission/environments/tree/master/dotnet20",
+    "runtimeVersion": "2.0.0",
+    "shortDescription": "Fission Dotnet 2.0.0 runtime uses Kestrel with Nancy to host the internal web server and uses Roslyn to compile the uploaded code.",
     "status": "Stable",
     "version": "1.31.1"
   }
@@ -377,75 +419,55 @@
 ,
 [
   {
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-debian",
+    "builder": "dotnet8-builder",
+    "examples": "https://github.com/fission/environments/tree/master/dotnet8/examples",
+    "icon": "./logo/logo_NETcore.svg",
+    "image": "dotnet8-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
         "link": "https://github.com/sanketsudake",
         "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
       }
     ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "20.16.0-debian",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "name": "Dotnet 8 Environment",
+    "readme": "https://github.com/fission/environments/tree/master/dotnet8",
+    "runtimeVersion": "8.0.0",
+    "shortDescription": "Fission Dotnet 8.0.0 runtime uses Kestrel to host the internal web server. Supports both single file compilation (--code) and project-based compilation (--src).",
     "status": "Stable",
-    "version": "1.32.4"
-  },
+    "version": "1.4.0"
+  }
+]
+,
+[
   {
-    "builder": "node-builder-22",
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-22",
+    "builder": "ruby-builder",
+    "examples": "https://github.com/fission/environments/tree/master/ruby/examples",
+    "icon": "./logo/Ruby_logo.svg",
+    "image": "ruby-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "22.6.0",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "name": "Ruby Environment",
+    "readme": "https://github.com/fission/environments/tree/master/ruby",
+    "runtimeVersion": "2.6.1",
+    "shortDescription": "Ruby environment with WEBrick library",
     "status": "Stable",
-    "version": "1.32.4"
-  },
-  {
-    "builder": "node-builder",
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "20.16.0",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
-    "status": "Stable",
-    "version": "1.32.4"
+    "version": "1.31.1"
   }
 ]
 

--- a/jvm/Dockerfile
+++ b/jvm/Dockerfile
@@ -1,5 +1,10 @@
-FROM maven:3.9.9-eclipse-temurin-22-alpine AS build
+FROM maven:3.9.16-eclipse-temurin-25-alpine AS build
 WORKDIR /usr/src/myapp/
+
+# fission-java-core is no longer resolvable from any remote repository,
+# so build and install it from source first.
+COPY install-fission-java-core.sh /usr/local/bin/install-fission-java-core
+RUN install-fission-java-core
 
 # To reuse the build cache, here we split maven dependency
 # download and package into two RUN commands to avoid cache invalidation.
@@ -9,7 +14,7 @@ RUN mvn dependency:go-offline
 COPY src /usr/src/myapp/src/
 RUN mvn package
 
-FROM eclipse-temurin:22-jdk-alpine
+FROM eclipse-temurin:25-jdk-alpine
 VOLUME /tmp
 COPY --from=build /usr/src/myapp/target/env-java-0.0.1-SNAPSHOT.jar /app.jar
 ENTRYPOINT java ${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /app.jar --server.port=8888

--- a/jvm/builder/Dockerfile
+++ b/jvm/builder/Dockerfile
@@ -2,9 +2,9 @@
 ARG BUILDER_IMAGE=fission/builder:latest
 FROM ${BUILDER_IMAGE} AS builder
 
-## Use eclipse-temurin:22-jdk-alpine - (https://github.com/adoptium/containers/blob/07677395574f5d3462c3b6fdf5f6c4a0a350b683/22/jdk/alpine/Dockerfile)
+## Use eclipse-temurin:25-jdk-alpine - (https://github.com/adoptium/containers)
 
-FROM eclipse-temurin:22-jdk-alpine
+FROM eclipse-temurin:25-jdk-alpine
 
 ## Section copied from the Maven Dockerfile
 
@@ -17,15 +17,20 @@ LABEL org.opencontainers.image.description="Apache Maven is a software project m
 
 ENV MAVEN_HOME=/usr/share/maven
 
-COPY --from=maven:3.9.9-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
-COPY --from=maven:3.9.9-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY --from=maven:3.9.9-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+COPY --from=maven:3.9.16-eclipse-temurin-25 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.16-eclipse-temurin-25 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.16-eclipse-temurin-25 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
 
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
-ARG MAVEN_VERSION=3.9.9
+ARG MAVEN_VERSION=3.9.16
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+## Pre-install fission-java-core into the local Maven repository so user
+## function builds can resolve it (it is no longer available remotely).
+COPY install-fission-java-core.sh /usr/local/bin/install-fission-java-core
+RUN install-fission-java-core
 
 ## Fission builder specific section
 COPY --from=builder /builder /builder

--- a/jvm/builder/install-fission-java-core.sh
+++ b/jvm/builder/install-fission-java-core.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# NOTE: keep in sync with ../install-fission-java-core.sh (duplicated because
+# the builder image is built with jvm/builder/ as its Docker build context).
+#
+# Installs io.fission:fission-java-core into the local Maven repository by
+# building it from source (a pinned commit of fission/fission-java-libs).
+#
+# Background: fission-java-core was only ever published as a SNAPSHOT to
+# oss.sonatype.org (OSSRH), which was decommissioned in 2025, so the artifact
+# can no longer be resolved from any remote repository.
+#
+# The artifact is installed under several versions so that both the poms in
+# this repository (0.0.2) and pre-existing user functions that still
+# reference 0.0.2-SNAPSHOT resolve from the local repository.
+set -eu
+
+COMMIT=e97baa8b6a306a552dc53d576075e7c410bcfaa4
+VERSIONS="0.0.1 0.0.2 0.0.2-SNAPSHOT"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+wget -qO "$workdir/src.tar.gz" "https://github.com/fission/fission-java-libs/archive/${COMMIT}.tar.gz"
+tar -xzf "$workdir/src.tar.gz" -C "$workdir"
+cd "$workdir/fission-java-libs-${COMMIT}/fission-java-core"
+
+# The pom is missing its XML namespace declarations, which strict plugin
+# parsers (e.g. versions-maven-plugin) reject; normalize the root element.
+sed -i '1s|^<project[^>]*>|<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">|' pom.xml
+
+for version in $VERSIONS; do
+    mvn -B -q versions:set -DnewVersion="$version"
+    mvn -B -q -DskipTests -Dmaven.compiler.release=17 install
+done

--- a/jvm/envconfig.json
+++ b/jvm/envconfig.json
@@ -22,9 +22,9 @@
     ],
     "name": "JVM Environment",
     "readme": "https://github.com/fission/environments/tree/master/jvm",
-    "runtimeVersion": "22",
+    "runtimeVersion": "25",
     "shortDescription": "JVM environment based on Spring Boot server",
     "status": "Stable",
-    "version": "1.31.3"
+    "version": "1.32.0"
   }
 ]

--- a/jvm/examples/java/pom.xml
+++ b/jvm/examples/java/pom.xml
@@ -13,19 +13,20 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>2.0.1.RELEASE</version>
+			<version>3.5.14</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.fission</groupId>
 			<artifactId>fission-java-core</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>0.0.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -52,7 +53,7 @@
 			<plugin>
             			<groupId>org.apache.maven.plugins</groupId>
             			<artifactId>maven-surefire-plugin</artifactId>
-            			<version>2.22.1</version>
+            			<version>3.5.4</version>
             			<configuration>
                 			<useSystemClassLoader>false</useSystemClassLoader>
             			</configuration>
@@ -60,13 +61,9 @@
 		</plugins>
 	</build>
 
-	<!-- Adding Sonatype repository to pull snapshots -->
-	<repositories>
-		<repository>
-			<id>fission-java-core</id>
-			<name>fission-java-core-snapshot</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
+	<!-- fission-java-core is not available in any remote repository; install
+	     it into the local Maven repository first by running
+	     jvm/install-fission-java-core.sh (the jvm-builder image ships with it
+	     pre-installed). -->
 
 </project>

--- a/jvm/install-fission-java-core.sh
+++ b/jvm/install-fission-java-core.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Installs io.fission:fission-java-core into the local Maven repository by
+# building it from source (a pinned commit of fission/fission-java-libs).
+#
+# Background: fission-java-core was only ever published as a SNAPSHOT to
+# oss.sonatype.org (OSSRH), which was decommissioned in 2025, so the artifact
+# can no longer be resolved from any remote repository.
+#
+# The artifact is installed under several versions so that both the poms in
+# this repository (0.0.2) and pre-existing user functions that still
+# reference 0.0.2-SNAPSHOT resolve from the local repository.
+set -eu
+
+COMMIT=e97baa8b6a306a552dc53d576075e7c410bcfaa4
+VERSIONS="0.0.1 0.0.2 0.0.2-SNAPSHOT"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+wget -qO "$workdir/src.tar.gz" "https://github.com/fission/fission-java-libs/archive/${COMMIT}.tar.gz"
+tar -xzf "$workdir/src.tar.gz" -C "$workdir"
+cd "$workdir/fission-java-libs-${COMMIT}/fission-java-core"
+
+# The pom is missing its XML namespace declarations, which strict plugin
+# parsers (e.g. versions-maven-plugin) reject; normalize the root element.
+sed -i '1s|^<project[^>]*>|<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">|' pom.xml
+
+for version in $VERSIONS; do
+    mvn -B -q versions:set -DnewVersion="$version"
+    mvn -B -q -DskipTests -Dmaven.compiler.release=17 install
+done

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.2</version>
+		<version>3.5.14</version>
 	</parent>
 
 	<dependencies>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>io.fission</groupId>
 			<artifactId>fission-java-core</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>0.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -39,12 +39,7 @@
 		</plugins>
 	</build>
 
-	<!-- Adding Sonatype repository to pull snapshots -->
-	<repositories>
-		<repository>
-			<id>fission-java-core</id>
-			<name>fission-java-core-snapshot</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
+	<!-- fission-java-core is built from source and installed into the local
+	     Maven repository (see install-fission-java-core.sh); no extra
+	     repositories are needed. -->
 </project>

--- a/jvm/tests/test_java_env.sh
+++ b/jvm/tests/test_java_env.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 source test_utils/utils.sh
 
+# Use the locally built image loaded into kind by `make jvm-test-images`
+# (the utils.sh default points at the stale Docker Hub image), matching the
+# convention of the go/binary/nodejs/python tests.
+export JVM_RUNTIME_IMAGE=jvm-env
+
 TEST_ID=$(generate_test_id)
 echo "TEST_ID = $TEST_ID"
 

--- a/jvm/tests/test_java_env.sh
+++ b/jvm/tests/test_java_env.sh
@@ -24,7 +24,14 @@ cd jvm/examples/java
 
 log "Creating the jar from application"
 #Using Docker to build Jar so that maven & other Java dependencies are not needed on CI server
-docker run --rm -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.9.9-eclipse-temurin-22-alpine mvn clean package -q
+#fission-java-core must be installed into the container-local Maven repository
+#first because it is not resolvable from any remote repository.
+docker run --rm \
+    -v "$(pwd)":/usr/src/mymaven \
+    -v "$(pwd)/../../install-fission-java-core.sh":/usr/local/bin/install-fission-java-core \
+    -w /usr/src/mymaven \
+    maven:3.9.16-eclipse-temurin-25-alpine \
+    sh -c "install-fission-java-core && mvn clean package -q"
 
 log "Creating environment for Java"
 fission env create --name $env --image $JVM_RUNTIME_IMAGE --version 2 --keeparchive=true


### PR DESCRIPTION
## Problem — why Java CI is failing

`io.fission:fission-java-core:0.0.2-SNAPSHOT` no longer resolves from anywhere:
- It was only ever published to the **oss.sonatype.org OSSRH snapshots repository, which has been decommissioned** (404 on both oss.sonatype.org and central.sonatype.com snapshots).
- It was never released to Maven Central (`repo1.maven.org/maven2/io/fission/` only contains `fission-jvm-jersey`).
- Source lives in [fission/fission-java-libs](https://github.com/fission/fission-java-libs) (two interfaces: `Function`, `Context`).

So `mvn package` fails for the env image, the builder's user-function builds, and the example function built by `jvm/tests/test_java_env.sh` (which builds in a clean maven container — fixing only the images would not fix CI).

## Fix

New `jvm/install-fission-java-core.sh`:
- Downloads fission-java-libs at pinned commit `e97baa8b` (immutable tarball), normalizes the 2018-era pom's missing XML namespace declarations (strict plugin parsers reject it), and `mvn install`s `fission-java-core` under **0.0.1, 0.0.2 and 0.0.2-SNAPSHOT**.
- The SNAPSHOT version keeps pre-existing user functions (whose poms still reference `0.0.2-SNAPSHOT`) building against the new `jvm-builder` image — Maven falls back to the local artifact when the dead remote is unreachable.
- Duplicated into `jvm/builder/` (that image's Docker build context is `jvm/builder/`; the copy carries a keep-in-sync note).

Used in three places: env image build stage, builder image (pre-seeds `/root/.m2`), and the CI test script before packaging the example.

Repo poms now reference `fission-java-core:0.0.2` (non-SNAPSHOT — never checked against remotes once installed locally) and drop the dead `oss.sonatype.org` `<repositories>` blocks.

## Version bumps

- Spring Boot parent 3.3.2 → **3.5.14** (latest 3.x)
- Java 22 (non-LTS, images no longer updated) → **25 LTS**: `maven:3.9.16-eclipse-temurin-25-alpine` / `eclipse-temurin:25-jdk-alpine`
- Example pom: `spring-boot-starter-web` 2.0.1.RELEASE → 3.5.14 (provided), surefire 2.22.1 → 3.5.4, `maven.compiler.release` 17
- `envconfig.json`: `runtimeVersion` 25, `version` 1.31.3 → **1.32.0** (triggers release on merge)
- `environments.json` regenerated via `make update-env-json` (was stale — still carried jvm 1.31.1)

## Verification (local)

- ✅ `jvm-env` image builds (`make jvm-env-img DOCKER_FLAGS=--load`)
- ✅ `jvm-builder` image builds; contains maven 3.9.16 + all three artifact versions in `/root/.m2`
- ✅ Example jar builds with the exact `docker run` command the CI test uses
- ✅ Container smoke test: Spring Boot 3.5.14 boots on Java 25.0.3, `POST /v2/specialize` → 200, `GET /` → `Hello World!`

## Related
- Built on top of the CI updates in #436 (independent — this PR works with the old workflow too).
- #409 (classNotFound fix in `Server.java`) intentionally not bundled — once this merges, re-running CI on #409 will give it a real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)