### PR TITLE
chore(jvm-jersey): upgrade to Java 25, Jersey 2.48 and Jetty 9.4.58

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -1,63 +1,151 @@
 [
 [
   {
-    "builder": "jvm-jersey-builder-11",
-    "examples": "https://github.com/fission/environments/tree/master/jvm-jersey/examples",
-    "icon": "./logo/Java-Logo.png",
-    "image": "jvm-jersey-env-11",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env-debian",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "JVM Environment",
-    "readme": "https://github.com/fission/environments/tree/master/jvm-jersey",
-    "runtimeVersion": "11",
-    "shortDescription": "JVM environment based on Jersey RESTful Web Services framework",
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0-debian",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.33"
+  },
+  {
+    "builder": "node-builder-22",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env-22",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "22.6.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.33"
+  },
+  {
+    "builder": "node-builder",
+    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
+    "icon": "./logo/nodejs-new-pantone-black.svg",
+    "image": "node-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Nodejs Environment",
+    "readme": "https://github.com/fission/environments/tree/master/nodejs",
+    "runtimeVersion": "20.16.0",
+    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "status": "Stable",
+    "version": "1.33"
   }
 ]
 ,
 [
   {
-    "builder": "ruby-builder",
-    "examples": "https://github.com/fission/environments/tree/master/ruby/examples",
-    "icon": "./logo/Ruby_logo.svg",
-    "image": "ruby-env",
-    "keywords": [],
+    "builder": "go-builder",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env",
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Ruby Environment",
-    "readme": "https://github.com/fission/environments/tree/master/ruby",
-    "runtimeVersion": "2.6.1",
-    "shortDescription": "Ruby environment with WEBrick library",
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.25",
+    "shortDescription": "Fission Go 1.25 environment, which uses dynamic loader based on Go plugins.",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.33.0"
+  },
+  {
+    "builder": "go-builder-1.25",
+    "examples": "https://github.com/fission/environments/tree/master/go/examples",
+    "icon": "./logo/go-logo-blue.svg",
+    "image": "go-env-1.25",
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Go Environment",
+    "readme": "https://github.com/fission/environments/tree/master/go",
+    "runtimeVersion": "1.25",
+    "shortDescription": "Fission Go 1.25 environment, which uses dynamic loader based on Go plugins.",
+    "status": "Stable",
+    "version": "1.33.0"
+  }
+]
+,
+[
+  {
+    "builder": "python-fastapi-builder",
+    "examples": "https://github.com/fission/environments/tree/master/python/examples",
+    "icon": "./logo/Python-logo-notext.png",
+    "image": "python-fastapi-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "Python FastAPI Environment",
+    "readme": "https://github.com/fission/environments/tree/master/python",
+    "runtimeVersion": "3.11",
+    "shortDescription": "Fission Python environment based on FastAPI framework.",
+    "status": "stable",
+    "version": "1.34.2"
   }
 ]
 ,
@@ -84,34 +172,68 @@
     "runtimeVersion": "3.11",
     "shortDescription": "Fission Python environment based on Flask framework.",
     "status": "stable",
-    "version": "1.34.1"
+    "version": "1.34.3"
   }
 ]
 ,
 [
   {
-    "builder": "binary-builder",
-    "examples": "https://github.com/fission/environments/tree/master/binary/examples",
-    "icon": "./logo/full_colored_dark.svg",
-    "image": "binary-env",
+    "examples": "https://github.com/fission/environments/tree/master/perl/examples",
+    "icon": "./logo/perl-programming-language.svg",
+    "image": "perl-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Fission Binary Environment",
-    "readme": "https://github.com/fission/environments/tree/master/binary",
-    "runtimeVersion": "3.20-alpine",
-    "shortDescription": "Fission environment to run any binary",
+    "name": "Perl Environment",
+    "readme": "https://github.com/fission/environments/tree/master/perl",
+    "runtimeVersion": "5",
+    "shortDescription": "Perl environment based on the Dancer2 framework",
     "status": "Stable",
-    "version": "1.32.2"
+    "version": "1.31.1"
+  }
+]
+,
+[
+  {
+    "builder": "jvm-builder",
+    "examples": "https://github.com/fission/environments/tree/master/jvm/examples",
+    "icon": "./logo/Java-Logo.png",
+    "image": "jvm-env",
+    "keywords": [],
+    "kind": "environment",
+    "maintainers": [
+      {
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
+      },
+      {
+        "link": "https://github.com/vishal-biyani",
+        "name": "vishal-biyani"
+      }
+    ],
+    "name": "JVM Environment",
+    "readme": "https://github.com/fission/environments/tree/master/jvm",
+    "runtimeVersion": "22",
+    "shortDescription": "JVM environment based on Spring Boot server",
+    "status": "Stable",
+    "version": "1.31.3"
   }
 ]
 ,
@@ -148,85 +270,6 @@
 ,
 [
   {
-    "builder": "dotnet20-builder",
-    "examples": "https://github.com/fission/environments/tree/master/dotnet20/examples",
-    "icon": "./logo/logo_NETcore.svg",
-    "image": "dotnet20-env",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Dotnet 2 Environment",
-    "readme": "https://github.com/fission/environments/tree/master/dotnet20",
-    "runtimeVersion": "2.0.0",
-    "shortDescription": "Fission Dotnet 2.0.0 runtime uses Kestrel with Nancy to host the internal web server and uses Roslyn to compile the uploaded code.",
-    "status": "Stable",
-    "version": "1.31.1"
-  }
-]
-,
-[
-  {
-    "builder": "go-builder",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env",
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.22",
-    "shortDescription": "Fission Go 1.22 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.32.3"
-  },
-  {
-    "builder": "go-builder-1.23",
-    "examples": "https://github.com/fission/environments/tree/master/go/examples",
-    "icon": "./logo/go-logo-blue.svg",
-    "image": "go-env-1.23",
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Go Environment",
-    "readme": "https://github.com/fission/environments/tree/master/go",
-    "runtimeVersion": "1.23",
-    "shortDescription": "Fission Go 1.23 environment, which uses dynamic loader based on Go plugins.",
-    "status": "Stable",
-    "version": "1.32.3"
-  }
-],
-[
-  {
     "examples": "https://github.com/fission/environments/tree/master/dotnet/examples",
     "icon": "./logo/dotnet-logo.svg",
     "image": "dotnet-env",
@@ -253,12 +296,14 @@
     "status": "Stable",
     "version": "1.31.1"
   }
-],[
+]
+,
+[
   {
-    "builder": "dotnet8-builder",
-    "examples": "https://github.com/fission/environments/tree/master/dotnet8/examples",
-    "icon": "./logo/logo_NETcore.svg",
-    "image": "dotnet8-env",
+    "builder": "jvm-jersey-builder-25",
+    "examples": "https://github.com/fission/environments/tree/master/jvm-jersey/examples",
+    "icon": "./logo/Java-Logo.png",
+    "image": "jvm-jersey-env-25",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -275,42 +320,39 @@
         "name": "vishal-biyani"
       }
     ],
-    "name": "Dotnet 8 Environment",
-    "readme": "https://github.com/fission/environments/tree/master/dotnet8",
-    "runtimeVersion": "8.0.18",
-    "shortDescription": "Fission Dotnet 8.0.18 runtime w/ .NET SDK 8.0.412 and ASP.NET Core 8.0.18",
+    "name": "JVM Environment",
+    "readme": "https://github.com/fission/environments/tree/master/jvm-jersey",
+    "runtimeVersion": "25",
+    "shortDescription": "JVM environment based on Jersey RESTful Web Services framework",
     "status": "Stable",
-    "version": "1.0.0"
+    "version": "1.32.0"
   }
 ]
 ,
 [
   {
-    "examples": "https://github.com/fission/environments/tree/master/perl/examples",
-    "icon": "./logo/perl-programming-language.svg",
-    "image": "perl-env",
+    "builder": "binary-builder",
+    "examples": "https://github.com/fission/environments/tree/master/binary/examples",
+    "icon": "./logo/full_colored_dark.svg",
+    "image": "binary-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/life1347",
-        "name": "life1347"
-      },
-      {
-        "link": "https://github.com/soamvasani",
-        "name": "soamvasani"
+        "link": "https://github.com/sanketsudake",
+        "name": "sanketsudake"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Perl Environment",
-    "readme": "https://github.com/fission/environments/tree/master/perl",
-    "runtimeVersion": "5",
-    "shortDescription": "Perl environment based on the Dancer2 framework",
+    "name": "Fission Binary Environment",
+    "readme": "https://github.com/fission/environments/tree/master/binary",
+    "runtimeVersion": "3.20-alpine",
+    "shortDescription": "Fission environment to run any binary",
     "status": "Stable",
-    "version": "1.31.1"
+    "version": "1.32.3"
   }
 ]
 ,
@@ -346,10 +388,10 @@
 ,
 [
   {
-    "builder": "jvm-builder",
-    "examples": "https://github.com/fission/environments/tree/master/jvm/examples",
-    "icon": "./logo/Java-Logo.png",
-    "image": "jvm-env",
+    "builder": "dotnet20-builder",
+    "examples": "https://github.com/fission/environments/tree/master/dotnet20/examples",
+    "icon": "./logo/logo_NETcore.svg",
+    "image": "dotnet20-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -366,10 +408,10 @@
         "name": "vishal-biyani"
       }
     ],
-    "name": "JVM Environment",
-    "readme": "https://github.com/fission/environments/tree/master/jvm",
-    "runtimeVersion": "8",
-    "shortDescription": "JVM environment based on Spring Boot server",
+    "name": "Dotnet 2 Environment",
+    "readme": "https://github.com/fission/environments/tree/master/dotnet20",
+    "runtimeVersion": "2.0.0",
+    "shortDescription": "Fission Dotnet 2.0.0 runtime uses Kestrel with Nancy to host the internal web server and uses Roslyn to compile the uploaded code.",
     "status": "Stable",
     "version": "1.31.1"
   }
@@ -377,75 +419,55 @@
 ,
 [
   {
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-debian",
+    "builder": "dotnet8-builder",
+    "examples": "https://github.com/fission/environments/tree/master/dotnet8/examples",
+    "icon": "./logo/logo_NETcore.svg",
+    "image": "dotnet8-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
         "link": "https://github.com/sanketsudake",
         "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
       }
     ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "20.16.0-debian",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "name": "Dotnet 8 Environment",
+    "readme": "https://github.com/fission/environments/tree/master/dotnet8",
+    "runtimeVersion": "8.0.0",
+    "shortDescription": "Fission Dotnet 8.0.0 runtime uses Kestrel to host the internal web server. Supports both single file compilation (--code) and project-based compilation (--src).",
     "status": "Stable",
-    "version": "1.32.4"
-  },
+    "version": "1.4.0"
+  }
+]
+,
+[
   {
-    "builder": "node-builder-22",
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env-22",
+    "builder": "ruby-builder",
+    "examples": "https://github.com/fission/environments/tree/master/ruby/examples",
+    "icon": "./logo/Ruby_logo.svg",
+    "image": "ruby-env",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
       {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
+        "link": "https://github.com/life1347",
+        "name": "life1347"
+      },
+      {
+        "link": "https://github.com/soamvasani",
+        "name": "soamvasani"
       },
       {
         "link": "https://github.com/vishal-biyani",
         "name": "vishal-biyani"
       }
     ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "22.6.0",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
+    "name": "Ruby Environment",
+    "readme": "https://github.com/fission/environments/tree/master/ruby",
+    "runtimeVersion": "2.6.1",
+    "shortDescription": "Ruby environment with WEBrick library",
     "status": "Stable",
-    "version": "1.32.4"
-  },
-  {
-    "builder": "node-builder",
-    "examples": "https://github.com/fission/environments/tree/master/nodejs/examples",
-    "icon": "./logo/nodejs-new-pantone-black.svg",
-    "image": "node-env",
-    "keywords": [],
-    "kind": "environment",
-    "maintainers": [
-      {
-        "link": "https://github.com/sanketsudake",
-        "name": "sanketsudake"
-      },
-      {
-        "link": "https://github.com/vishal-biyani",
-        "name": "vishal-biyani"
-      }
-    ],
-    "name": "Nodejs Environment",
-    "readme": "https://github.com/fission/environments/tree/master/nodejs",
-    "runtimeVersion": "20.16.0",
-    "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
-    "status": "Stable",
-    "version": "1.32.4"
+    "version": "1.31.1"
   }
 ]
 

--- a/jvm-jersey/Dockerfile
+++ b/jvm-jersey/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-22-alpine AS build
+FROM maven:3.9.16-eclipse-temurin-25-alpine AS build
 WORKDIR /usr/src/myapp/
 
 # To reuse the build cache, here we split maven dependency
@@ -9,7 +9,7 @@ RUN mvn dependency:go-offline
 COPY src /usr/src/myapp/src/
 RUN mvn package
 
-FROM eclipse-temurin:22-jdk-alpine
+FROM eclipse-temurin:25-jdk-alpine
 COPY --from=build /usr/src/myapp/target/env-jvm-jersey-0.0.1.jar /app.jar
 ENTRYPOINT java ${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /app.jar 8888
 EXPOSE 8888

--- a/jvm-jersey/Makefile
+++ b/jvm-jersey/Makefile
@@ -1,6 +1,6 @@
 -include ../rules.mk
 
 .PHONY: all
-all: jvm-jersey-env-22-img
+all: jvm-jersey-env-25-img
 
-jvm-jersey-env-22-img: Dockerfile
+jvm-jersey-env-25-img: Dockerfile

--- a/jvm-jersey/builder/Dockerfile
+++ b/jvm-jersey/builder/Dockerfile
@@ -2,9 +2,9 @@
 ARG BUILDER_IMAGE=fission/builder
 FROM ${BUILDER_IMAGE} AS builder
 
-## From the eclipse-temurin:22-jdk-alpine - (https://github.com/adoptium/containers/blob/07677395574f5d3462c3b6fdf5f6c4a0a350b683/22/jdk/alpine/Dockerfile)
+## From the eclipse-temurin:25-jdk-alpine - (https://github.com/adoptium/containers)
 
-FROM eclipse-temurin:22-jdk-alpine
+FROM eclipse-temurin:25-jdk-alpine
 
 ## Section copied from the Maven Dockerfile
 
@@ -17,13 +17,13 @@ LABEL org.opencontainers.image.description="Apache Maven is a software project m
 
 ENV MAVEN_HOME=/usr/share/maven
 
-COPY --from=maven:3.9.9-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
-COPY --from=maven:3.9.9-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY --from=maven:3.9.9-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+COPY --from=maven:3.9.16-eclipse-temurin-25 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.16-eclipse-temurin-25 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.16-eclipse-temurin-25 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
 
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
-ARG MAVEN_VERSION=3.9.9
+ARG MAVEN_VERSION=3.9.16
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 

--- a/jvm-jersey/builder/Makefile
+++ b/jvm-jersey/builder/Makefile
@@ -1,6 +1,6 @@
 -include ../../rules.mk
 
 .PHONY: all
-all: jvm-jersey-builder-22-img
+all: jvm-jersey-builder-25-img
 
-jvm-jersey-builder-22-img: Dockerfile
+jvm-jersey-builder-25-img: Dockerfile

--- a/jvm-jersey/envconfig.json
+++ b/jvm-jersey/envconfig.json
@@ -1,9 +1,9 @@
 [
   {
-    "builder": "jvm-jersey-builder-22",
+    "builder": "jvm-jersey-builder-25",
     "examples": "https://github.com/fission/environments/tree/master/jvm-jersey/examples",
     "icon": "./logo/Java-Logo.png",
-    "image": "jvm-jersey-env-22",
+    "image": "jvm-jersey-env-25",
     "keywords": [],
     "kind": "environment",
     "maintainers": [
@@ -22,9 +22,9 @@
     ],
     "name": "JVM Environment",
     "readme": "https://github.com/fission/environments/tree/master/jvm-jersey",
-    "runtimeVersion": "22",
+    "runtimeVersion": "25",
     "shortDescription": "JVM environment based on Jersey RESTful Web Services framework",
     "status": "Stable",
-    "version": "1.31.2"
+    "version": "1.32.0"
   }
 ]

--- a/jvm-jersey/examples/java/pom.xml
+++ b/jvm-jersey/examples/java/pom.xml
@@ -12,8 +12,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>22</maven.compiler.source>
-		<maven.compiler.target>22</maven.compiler.target>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/jvm-jersey/pom.xml
+++ b/jvm-jersey/pom.xml
@@ -8,9 +8,9 @@
 	<version>0.0.1</version>
 
 	<properties>
-        <maven.compiler.release>22</maven.compiler.release>
-		<jetty.version>9.4.55.v20240627</jetty.version>
-		<jersey.version>2.41</jersey.version>
+        <maven.compiler.release>25</maven.compiler.release>
+		<jetty.version>9.4.58.v20250814</jetty.version>
+		<jersey.version>2.48</jersey.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What

Part of the dependency-update series (#436, #437). Updates the jvm-jersey environment:

- **Jersey 2.41 → 2.48**, **Jetty 9.4.55.v20240627 → 9.4.58.v20250814** (latest 9.4.x)
- **Java 22 → 25 LTS** — temurin-22 images are no longer updated (non-LTS). Build: `maven:3.9.16-eclipse-temurin-25-alpine`; runtime: `eclipse-temurin:25-jdk-alpine`. The builder image previously copied Maven from a `temurin-11` image; it now uses a consistent 3.9.16/temurin-25 source.
- Image/builder names follow the existing version-suffix convention: `jvm-jersey-env-22` → `jvm-jersey-env-25`, `jvm-jersey-builder-22` → `jvm-jersey-builder-25` (Makefile targets renamed to match — release workflow derives target names from envconfig.json).
- `envconfig.json`: `runtimeVersion` 25, `version` 1.31.2 → **1.32.0**; `environments.json` regenerated via `make update-env-json`.

Unlike the sibling jvm env (#437), this env's `io.fission:fission-jvm-jersey:0.0.1` dependency is released on Maven Central and still resolves — no dependency surgery needed.

## Verification (local)

- ✅ `jvm-jersey-env-25` and `jvm-jersey-builder-25` images build (`DOCKER_FLAGS=--load`)
- ✅ Container smoke test: Jetty 9.4.58.v20250814 boots on JVM 25.0.3+9-LTS, returns the expected "Container not specialized" 400 before specialization

## Note

There is no jvm-jersey CI job on master today (a path filter exists but no job consumes it) — #436 adds a build job for it. Until #436 merges, no env-specific CI will run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)