### PR TITLE
ci: handle brand-new images and workflow_dispatch in release_check

### DIFF
--- a/hack/release_check.py
+++ b/hack/release_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import glob
 import json
 import os
 import sys
@@ -13,6 +14,11 @@ def check_if_image_exists(image,tag):
     # GHCR v2 API needs a bearer token even for public images;
     # an anonymous token is sufficient for pull scope.
     token_resp = requests.get(GHCR_TOKEN_URL.format(org=GHCR_ORG, env=image), timeout=30)
+    if token_resp.status_code in (401, 403, 404):
+        # GHCR refuses to issue a pull token for packages that do not exist
+        # yet (e.g. a brand-new image name) -> release needed.
+        print(f"GHCR token denied for '{image}' ({token_resp.status_code}); assuming the package does not exist yet")
+        return False
     token_resp.raise_for_status()
     token = token_resp.json().get("token")
     if not token:
@@ -42,6 +48,13 @@ def main(package_list_str):
     package_list = package_list_str.strip("[]")
     package_list = [p.strip().strip('"') for p in package_list.split(',') if p.strip()]
 
+    if not package_list:
+        # No changed packages (e.g. workflow_dispatch, where the paths filter
+        # has no diff): reconcile every environment so any envconfig version
+        # that never got published is picked up.
+        package_list = sorted(os.path.dirname(p) for p in glob.glob("*/envconfig.json"))
+        print(f"No packages passed; reconciling all environments: {package_list}")
+
     print(package_list, type(package_list))
     versions_to_be_released = []
     for package in package_list:
@@ -67,4 +80,4 @@ def main(package_list_str):
     set_output("release_needed", "true" if release_needed else "false")
 
 if __name__ == "__main__":
-   main(sys.argv[1])
+   main(sys.argv[1] if len(sys.argv) > 1 else "")


### PR DESCRIPTION
## What

Follow-up fix to the #436 release-gate repair, surfaced by the first real release runs after #437/#438 merged:

1. **New-image case:** GHCR's token endpoint returns **403** for packages that don't exist yet, so the fail-closed gate crashed on the first-ever release of `jvm-jersey-env-25` ([failed run](https://github.com/fission/environments/actions/runs/27067110904)). Token 401/403/404 now maps to "package missing → release needed"; 5xx/network errors still fail closed.
2. **`workflow_dispatch` reconcile mode:** on manual dispatch the paths filter has no diff, so the gate previously did nothing. With an empty package list it now scans every `*/envconfig.json` and releases anything whose version isn't on GHCR — making dispatch a "reconcile all" button.

## Verified live against GHCR

Reconcile mode correctly flags the current unpublished backlog — `jvm-jersey-env-25:1.32.0` (the failed run above), `python-env:1.34.3` (pre-existing backlog from the broken gate), `php-env:1.31.2`, legacy `dotnet-env`/`dotnet20-env` `1.31.1` — and skips everything already published.

## After merge

Run `gh workflow run release.yaml` once to backfill the missed releases (heads-up: the legacy dotnet 1.1/2.0 matrix legs may fail to build — they're EOL images on the deprecated `microsoft/dotnet` base and were left untouched in this series; `fail-fast: false` keeps the other legs going).

🤖 Generated with [Claude Code](https://claude.com/claude-code)