### PR TITLE
chore(nodejs): bump env version to 1.35 for refreshed dependency lockfile

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -21,7 +21,7 @@
     "runtimeVersion": "22.22.3-debian",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   },
   {
     "builder": "node-builder-22",
@@ -45,7 +45,7 @@
     "runtimeVersion": "22.22.3",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   },
   {
     "builder": "node-builder",
@@ -69,7 +69,7 @@
     "runtimeVersion": "22.22.3",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   }
 ]
 ,

--- a/nodejs/envconfig.json
+++ b/nodejs/envconfig.json
@@ -20,7 +20,7 @@
     "runtimeVersion": "22.22.3-debian",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   },
   {
     "builder": "node-builder-22",
@@ -44,7 +44,7 @@
     "runtimeVersion": "22.22.3",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   },
   {
     "builder": "node-builder",
@@ -68,6 +68,6 @@
     "runtimeVersion": "22.22.3",
     "shortDescription": "Fission NodeJS environment based on Express with some basic dependencies added",
     "status": "Stable",
-    "version": "1.34"
+    "version": "1.35"
   }
 ]


### PR DESCRIPTION
Releases new nodejs images picking up the lockfile refresh from #450 (path-to-regexp 8.2.0 → 8.4.2).

- `nodejs/envconfig.json`: all three entries `1.34` → **`1.35`**
- `environments.json` regenerated via `make update-env-json`

CI runs the full nodejs e2e on this PR; merge triggers the release workflow to publish `node-env:1.35`, `node-env-22:1.35`, `node-env-debian:1.35` + builders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)