### PR TITLE
Fix broken examples links in environment READMEs

### DIFF
--- a/binary/README.md
+++ b/binary/README.md
@@ -17,7 +17,7 @@ See 'Compiling' for instructions.
 When executing functions using binaries, **ensure that the executable is built for the right architecture**.
 Using the default binary environment this means that the binary should be build for Linux.
 
-Looking for ready-to-run examples? See the [binary examples directory](./examples).
+Looking for ready-to-run examples? See the [binary examples directory](https://github.com/fission/examples/tree/main/miscellaneous/binary).
 
 ## Usage
 

--- a/dotnet8/README.md
+++ b/dotnet8/README.md
@@ -31,7 +31,7 @@ public class MyFunction {
 }
 ```
 
-Please see examples below. Ready-to-run examples are available in the examples directory:
+Please see examples below. Ready-to-run examples are available in the [fission/examples repo](https://github.com/fission/examples/tree/main/dotnet8):
 - **HelloWorld** - Basic function demonstration
 - **HttpTriggerExample** - HTTP request handling with context detection
 - **AsyncFunctionExample** - Demonstrates async/await patterns

--- a/perl/README.md
+++ b/perl/README.md
@@ -9,7 +9,7 @@ It is implemented using the lightweight web application framework
 Since Twiggy is implemented with [AnyEvent](https://metacpan.org/pod/AnyEvent),
 you can write async code using AnyEvent in your function.
 
-Looking for ready-to-run examples? See the [Perl examples directory](./examples).
+Looking for ready-to-run examples? See the [Perl examples directory](https://github.com/fission/examples/tree/main/perl).
 
 ## Build this image
    

--- a/python-fastapi/README.md
+++ b/python-fastapi/README.md
@@ -6,7 +6,7 @@ It's a Docker image containing a Python 3.13 runtime, along with a
 dynamic loader.  A few common dependencies are included in the
 requirements.txt file.
 
-Looking for ready-to-run examples? See the [Python FastAPI examples directory](./examples).
+Looking for ready-to-run examples? See the [Python FastAPI examples directory](https://github.com/fission/examples/tree/main/python-fastapi).
 
 ## Customizing this image
 

--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@ It's a Docker image containing a Python 3.5 runtime, along with a
 dynamic loader.  A few common dependencies are included in the
 requirements.txt file.
 
-Looking for ready-to-run examples? See the [Python examples directory](./examples).
+Looking for ready-to-run examples? See the [Python examples directory](https://github.com/fission/examples/tree/main/python).
 
 ## Customizing this image
 


### PR DESCRIPTION
## What

After [#454](https://github.com/fission/environments/pull/454) moved examples to [fission/examples](https://github.com/fission/examples), a few READMEs still linked to the now-deleted local `examples/` dir. The earlier pass missed these because they used `](./examples)` (no trailing slash).

Fixed broken links:
- `python/README.md`, `python-fastapi/README.md`, `perl/README.md`, `binary/README.md` — `./examples` → `github.com/fission/examples/tree/main/<path>` (binary → `miscellaneous/binary`)
- `dotnet8/README.md` — prose "examples directory" now links to `fission/examples/tree/main/dotnet8`

## Verification

Ran a markdown link checker across the repo (relative-path existence + environments `examples/` URLs): **0 broken links remain**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)